### PR TITLE
fix: Add missing link to Upload Config page

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -32,6 +32,7 @@
           <li><a href="/admin/blocks" class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-700 hover:text-white">📦 Manage Blocks</a></li>
           <li><a href="/admin/users" class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-700 hover:text-white">👤 Manage Users</a></li>
           <li><a href="/dashboard/churned" class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-700 hover:text-white">📉 Churned Allocations</a></li>
+        <li><a href="/dashboard/upload_config" class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-700 hover:text-white">☁️ Upload Config</a></li>
           {% endif %}
         </ul>
       </nav>


### PR DESCRIPTION
This commit adds the navigation link for the 'Upload Config' feature to the main sidebar in `templates/layout.html`.

The feature was implemented, but the link was omitted by mistake, making the page inaccessible from the UI. This change makes the feature discoverable for admin users.