### PR TITLE
feat: Group imported Cisco IPs into a single supernet block

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -5,14 +5,19 @@ from sqlalchemy.orm import Session
 from ciscoconfparse import CiscoConfParse
 
 from database import get_db
-from models import SubnetStatus
+from models import SubnetStatus, User
 import crud
-from security import get_current_user, admin_required
+from security import get_current_user
 
 router = APIRouter(prefix="/import", tags=["Import"])
 
 
-@router.post("/cisco-config", dependencies=[Depends(admin_required)])
+def require_admin(user: User = Depends(get_current_user)):
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+
+@router.post("/cisco-config", dependencies=[Depends(require_admin)])
 def import_cisco_config(
     request: Request,
     file: UploadFile = File(...),
@@ -37,10 +42,15 @@ def import_cisco_config(
     device = crud.get_or_create_device(db, hostname=hostname)
 
     intfs = parse.find_objects(r"^interface\s+")
-    imported = 0
+    networks = []
     for intf in intfs:
         name = intf.text.split(None, 1)[1].strip()
         iface = crud.get_or_create_interface(db, device, name)
+
+        description = ""
+        desc_line = intf.re_search_children(r"^\s+description\s+")
+        if desc_line:
+            description = desc_line[0].text.strip().split(None, 1)[1]
 
         ip_lines = intf.re_search_children(r"^\s+ip address\s+")
         for l in ip_lines:
@@ -51,20 +61,50 @@ def import_cisco_config(
                 mask = parts[3]
                 try:
                     network = ipaddress.ip_network(f"{ip}/{mask}", strict=False)
+                    networks.append(
+                        {"network": network, "iface": iface, "ip": ip, "description": description}
+                    )
                 except ValueError:
                     continue
 
-                # Decide/ensure block
-                block_cidr = crud.suggest_block_for_network(network)
-                block = crud.get_or_create_block(db, block_cidr, created_by=user.username, description="auto-import")
+    imported = 0
+    if networks:
+        # Calculate single supernet
+        nets_to_summarize = [n["network"] for n in networks]
+        first_ip = min(net.network_address for net in nets_to_summarize)
+        last_ip = max(net.broadcast_address for net in nets_to_summarize)
 
+        supernet = ipaddress.ip_network(f"{first_ip}/32")
+        while last_ip not in supernet:
+            supernet = supernet.supernet()
+
+        if supernet:
+            block = crud.get_or_create_block(
+                db, str(supernet), created_by=user.username, description="auto-import-cisco"
+            )
+        else:
+            # Fallback or error
+            # For now, just process without a single block, though this case is unlikely with valid IPs
+            block = None
+
+        # Create subnets
+        for net_info in networks:
+            network = net_info["network"]
+            iface = net_info["iface"]
+            ip = net_info["ip"]
+            description = net_info["description"]
+
+            parent_block = block # Use the single block for all subnets
+
+            if parent_block:
                 # Ensure subnet exists
                 subnet = crud.create_or_get_subnet(
                     db,
                     str(network.with_prefixlen),
-                    block,
+                    parent_block,
                     status=SubnetStatus.imported,
-                    created_by=user.username
+                    created_by=user.username,
+                    description=description
                 )
 
                 # Add the interface address record

--- a/security.py
+++ b/security.py
@@ -1,5 +1,5 @@
 from passlib.context import CryptContext
-from fastapi import Request, HTTPException
+from fastapi import Request, HTTPException, Depends
 from sqlalchemy.orm import Session
 from database import SessionLocal
 from models import User
@@ -23,7 +23,7 @@ def get_db():
 
 from models import Setting
 
-def get_current_user(request: Request, db: Session):
+def get_current_user(request: Request, db: Session = Depends(get_db)):
     user_id = request.session.get("user_id")
     if not user_id:
         raise HTTPException(status_code=401, detail="Not authenticated")


### PR DESCRIPTION
Refactors the Cisco configuration import functionality to group all imported IP addresses under a single, calculated supernet block.

Previously, each IP address from the configuration was created as a separate block, which was not the desired behavior.

This change introduces the following improvements:
- When a Cisco configuration is uploaded, the system now calculates the smallest possible supernet that contains all the IP addresses in the file.
- A single IP block is created for this supernet.
- All the subnets from the configuration are then created under this parent block.
- The interface description from the config is now used as the description for the created subnet.

Additionally, the authentication dependency for the import endpoint has been refactored for clarity and correctness.