### PR TITLE
feat: Implement manual parent block assignment for imports

### DIFF
--- a/templates/edit_allocation.html
+++ b/templates/edit_allocation.html
@@ -8,6 +8,18 @@
     <p class="text-slate-500">Update the details for this subnet.</p>
 </div>
 
+{% if subnet.status.name == 'inactive' %}
+<div class="bg-amber-50 border-l-4 border-amber-400 text-amber-800 p-4 rounded-md mb-6 shadow-sm" role="alert">
+  <div class="flex">
+    <div class="py-1"><svg class="fill-current h-6 w-6 text-amber-500 mr-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M2.93 17.07A10 10 0 1 1 17.07 2.93 10 10 0 0 1 2.93 17.07zM9 5v6h2V5H9zm0 8v2h2v-2H9z"/></svg></div>
+    <div>
+      <p class="font-bold">This subnet is inactive.</p>
+      <p class="text-sm">It was imported without a matching parent block. Please assign it to a valid block to activate it.</p>
+    </div>
+  </div>
+</div>
+{% endif %}
+
 <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6 max-w-2xl mx-auto">
   <form method="post" action="/dashboard/allocations/{{ subnet.id }}/edit" class="space-y-4">
 
@@ -23,6 +35,17 @@
         {% for vlan in vlans %}
           <option value="{{ vlan.id }}" {% if subnet.vlan_id == vlan.id %}selected{% endif %}>
             {{ vlan.vlan_id }} - {{ vlan.name }}
+          </option>
+        {% endfor %}
+      </select>
+    </div>
+
+    <div>
+      <label for="block_id" class="text-sm font-medium text-slate-600 block mb-1">Parent Block</label>
+      <select name="block_id" id="block_id" class="w-full border-slate-300 rounded-md shadow-sm focus:border-sky-500 focus:ring-sky-500" required>
+        {% for block in blocks %}
+          <option value="{{ block.id }}" {% if subnet.block_id == block.id %}selected{% endif %}>
+            {{ block.cidr }} {% if block.description %}({{ block.description }}){% endif %}
           </option>
         {% endfor %}
       </select>

--- a/templates/upload_config.html
+++ b/templates/upload_config.html
@@ -1,11 +1,27 @@
 {% extends "layout.html" %}
 {% block title %}Upload Config - EDEMROBIN{% endblock %}
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">Upload Device Config</h1>
+<div class="mb-6 border-b border-slate-200 pb-4">
+  <h1 class="text-2xl font-bold text-slate-700">Upload Device Config</h1>
+  <p class="text-slate-500">Upload a Cisco configuration file to import subnets.</p>
+</div>
 
-<form action="/dashboard/upload_config" method="post" enctype="multipart/form-data"
-      class="bg-white rounded-xl shadow p-4 flex items-center gap-3">
-  <input type="file" name="file" class="border rounded px-3 py-2" required>
-  <button type="submit" class="bg-gray-900 text-white rounded px-4 py-2">Upload</button>
-</form>
+<div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+    <form action="/import/cisco-config" method="post" enctype="multipart/form-data">
+        <div class="mb-6">
+            <label for="parent_blocks" class="block text-sm font-medium text-slate-600 mb-1">Parent Blocks (comma-separated)</label>
+            <input type="text" name="parent_blocks" id="parent_blocks" placeholder="e.g., 192.50.24.0/24, 10.10.0.0/16" class="w-full border-slate-300 rounded-md shadow-sm focus:border-sky-500 focus:ring-sky-500" required>
+            <p class="text-xs text-slate-400 mt-1">Provide the parent CIDR blocks to group the imported subnets.</p>
+        </div>
+
+        <div class="mb-6">
+            <label for="file" class="block text-sm font-medium text-slate-600 mb-1">Configuration File</label>
+            <input type="file" name="file" id="file" class="w-full border-slate-300 rounded-md shadow-sm file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:bg-slate-100 file:text-slate-700 hover:file:bg-slate-200" required>
+        </div>
+
+        <div class="flex justify-end">
+            <button type="submit" class="bg-slate-800 text-white font-semibold rounded-lg px-5 py-2.5 text-sm hover:bg-slate-700 transition">Upload and Process</button>
+        </div>
+    </form>
+</div>
 {% endblock %}

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,47 +1,5 @@
 import unittest
-import ipaddress
-from utils import parse_config, group_networks_by_supernet
-
-
-class TestGroupNetworksBySupernet(unittest.TestCase):
-
-    def test_basic_grouping(self):
-        networks = [
-            ipaddress.ip_network('192.168.1.0/28'),
-            ipaddress.ip_network('192.168.1.16/28'),
-            ipaddress.ip_network('192.168.2.0/26'),
-            ipaddress.ip_network('10.0.0.0/8'),
-        ]
-        grouped = group_networks_by_supernet(networks, prefixlen=24)
-        self.assertIn('192.168.1.0/24', grouped)
-        self.assertEqual(len(grouped['192.168.1.0/24']), 2)
-        self.assertIn('192.168.2.0/24', grouped)
-        self.assertEqual(len(grouped['192.168.2.0/24']), 1)
-        self.assertIn('10.0.0.0/8', grouped)
-        self.assertEqual(len(grouped['10.0.0.0/8']), 1)
-
-    def test_grouping_with_larger_prefix(self):
-        networks = [
-            ipaddress.ip_network('172.16.1.0/24'),
-            ipaddress.ip_network('172.16.2.0/24'),
-            ipaddress.ip_network('172.17.1.0/24'),
-        ]
-        grouped = group_networks_by_supernet(networks, prefixlen=16)
-        self.assertIn('172.16.0.0/16', grouped)
-        self.assertEqual(len(grouped['172.16.0.0/16']), 2)
-        self.assertIn('172.17.0.0/16', grouped)
-        self.assertEqual(len(grouped['172.17.0.0/16']), 1)
-
-    def test_empty_input(self):
-        grouped = group_networks_by_supernet([], prefixlen=24)
-        self.assertEqual(grouped, {})
-
-    def test_network_larger_than_prefix(self):
-        networks = [ipaddress.ip_network('10.0.0.0/8')]
-        grouped = group_networks_by_supernet(networks, prefixlen=24)
-        self.assertIn('10.0.0.0/8', grouped)
-        self.assertEqual(len(grouped['10.0.0.0/8']), 1)
-
+from utils import parse_config
 
 class TestAdvancedParseConfig(unittest.TestCase):
 

--- a/utils.py
+++ b/utils.py
@@ -124,21 +124,3 @@ def parse_config(config_text: str):
     else:
         print("WARNING: Could not determine config type. Falling back to Cisco parser.")
         return parse_cisco_config(config_text)
-
-from collections import defaultdict
-
-def group_networks_by_supernet(networks: list[ipaddress.IPv4Network], prefixlen: int = 24) -> dict[str, list[ipaddress.IPv4Network]]:
-    """
-    Groups a list of ipaddress networks by a containing supernet of a given prefix length.
-    """
-    grouped = defaultdict(list)
-    for network in networks:
-        # Handle cases where the network is larger than the target prefixlen
-        if network.prefixlen < prefixlen:
-            supernet = network
-        else:
-            supernet = network.supernet(new_prefix=prefixlen)
-
-        grouped[str(supernet)].append(network)
-
-    return dict(grouped)


### PR DESCRIPTION
This change revamps the Cisco configuration import process to allow for manual assignment of parent blocks and handles various subnet statuses based on the import context.

Key changes:
- The config upload form now has a field for the user to provide a comma-separated list of parent CIDR blocks.
- The import logic in `routes_import.py` is updated to:
  - Assign imported subnets to the appropriate user-specified parent block.
  - Assign subnets that do not fit into any specified parent to a default "Unassigned" block and mark them as 'inactive'.
  - Assign subnets from administratively 'shutdown' interfaces to a 'deactivated' status, which makes them appear on the "Churned Allocations" page.
- The "Edit Allocation" page now allows changing the parent block of a subnet.
- A visual indicator is added to the "Edit Allocation" page to highlight inactive subnets.