### PR TITLE
feat: Overhaul Cisco config import with manual block assignment

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -61,7 +61,7 @@ def import_cisco_config(
         name = intf.text.split(None, 1)[1].strip()
         iface = crud.get_or_create_interface(db, device, name)
 
-        is_shutdown = intf.is_shutdown
+        is_shutdown = len(intf.re_search_children(r"^\s*shutdown\s*$")) > 0
 
         description = ""
         desc_line = intf.re_search_children(r"^\s+description\s+")


### PR DESCRIPTION
This commit introduces a complete overhaul of the Cisco configuration import process, moving from automatic block detection to a user-driven workflow. It also incorporates robust handling for various real-world scenarios like unassigned subnets and administratively shutdown interfaces.

Key features and fixes:
- **Manual Parent Blocks**: The config upload form now includes a required field for the administrator to specify a comma-separated list of parent CIDR blocks.
- **'Unassigned' Block**: Subnets from the import that do not fit into any of the user-provided parent blocks are now placed into a default "Unassigned" block and given an 'inactive' status.
- **'Deactivated' Status for Shutdown Interfaces**: The import logic now correctly detects administratively `shutdown` interfaces and assigns the corresponding subnets a 'deactivated' status, which correctly places them on the "Churned Allocations" page.
- **Edit and Activate Subnets**: The "Edit Allocation" page has been enhanced to allow changing a subnet's parent block. Moving a subnet from the "Unassigned" block to a valid block now automatically changes its status from 'inactive' to 'allocated'.
- **Bug Fix**: Fixed a critical `AttributeError` by replacing the incorrect `intf.is_shutdown` with the correct `ciscoconfparse` method `intf.re_search_children(r"^\s*shutdown\s*$")` to check for shutdown status.
- **UI Indicator**: Added a visual warning on the "Edit Allocation" page for subnets that are 'inactive'.