### PR TITLE
feat: Overhaul Cisco config import with manual block assignment

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,9 +62,9 @@ def home(request: Request, block_id: Optional[int] = None, db: Session = Depends
 
     # Get blocks this user is allowed to see for the stats cards
     if user.is_admin:
-        blocks_for_stats = db.query(models.IPBlock).order_by(models.IPBlock.cidr).all()
+        blocks_for_stats = db.query(models.IPBlock).filter(models.IPBlock.cidr != 'Unassigned').order_by(models.IPBlock.cidr).all()
     else:
-        blocks_for_stats = user.allowed_blocks
+        blocks_for_stats = [b for b in user.allowed_blocks if b.cidr != 'Unassigned']
         blocks_for_stats.sort(key=lambda x: ipaddress.ip_network(x.cidr))
 
     block_stats = []


### PR DESCRIPTION
This commit introduces a complete overhaul of the Cisco configuration import process, moving from automatic block detection to a user-driven workflow. It also incorporates robust handling for various real-world scenarios like unassigned subnets and administratively shutdown interfaces, and fixes several bugs identified during development.

Key features and fixes:
- **Manual Parent Blocks**: The config upload form now includes a required field for the administrator to specify a comma-separated list of parent CIDR blocks.
- **'Unassigned' Block**: Subnets from the import that do not fit into any of the user-provided parent blocks are now placed into a default "Unassigned" block and given an 'inactive' status.
- **'Deactivated' Status for Shutdown Interfaces**: The import logic now correctly detects administratively `shutdown` interfaces and assigns the corresponding subnets a 'deactivated' status, which correctly places them on the "Churned Allocations" page.
- **Edit and Activate Subnets**: The "Edit Allocation" page has been enhanced to allow changing a subnet's parent block. Moving a subnet from the "Unassigned" block to a valid block now automatically changes its status from 'inactive' to 'allocated'.
- **UI Indicator**: Added a visual warning on the "Edit Allocation" page for subnets that are 'inactive'.
- **Bug Fix (Shutdown Check)**: Fixed a critical `AttributeError` by replacing an incorrect attribute access with the correct `ciscoconfparse` method `intf.re_search_children()` to check for shutdown status.
- **Bug Fix (Dashboard Crash)**: Fixed a `ValueError` on the main dashboard by filtering out the non-routable "Unassigned" block from the utilization statistics calculation.