### PR TITLE
feat: Add VLAN creation, stats fix, and redirect on import

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,8 +73,8 @@ def home(request: Request, block_id: Optional[int] = None, db: Session = Depends
         total_ips = parent_network.num_addresses
 
         used_ips = 0
-        # Filter subnets by status to not include 'imported' or 'inactive' as 'used' in the main stat
-        active_subnets = [s for s in block.subnets if s.status == models.SubnetStatus.allocated]
+        # Filter subnets by status to not include 'inactive' as 'used' in the main stat
+        active_subnets = [s for s in block.subnets if s.status in [models.SubnetStatus.allocated, models.SubnetStatus.imported]]
         for subnet in active_subnets:
             used_ips += ipaddress.ip_network(subnet.cidr).num_addresses
 


### PR DESCRIPTION
This commit builds upon the new manual import process by adding several key features and fixes based on user feedback.

- **VLAN Creation from Sub-interfaces**: The import logic now parses sub-interface names (e.g., `GigabitEthernet0/0.100`) to extract the VLAN ID. It then creates a corresponding VLAN in the database if one does not already exist and associates it with the imported subnet.
- **Dashboard Statistics Fix**: The main dashboard's utilization statistics now correctly include subnets with an 'imported' status in the 'used IPs' calculation, providing a more accurate overview of block utilization immediately after an import.
- **Redirect After Import**: The user experience of the config import has been improved by replacing the raw JSON response with a redirect back to the main dashboard upon successful completion.