### PR TITLE
feat: Overhaul Cisco config import and fix critical bugs

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -113,3 +113,54 @@ def suggest_block_for_network(network: ipaddress.IPv4Network) -> str:
     if network.prefixlen <= 16:
         return str(network)
     return str(network.supernet(new_prefix=16))
+
+# ---------- Non-committing versions for bulk operations ----------
+
+def create_vlan_no_commit(db: Session, vlan_id: int, name: str, created_by: str, site: str | None = None) -> VLAN:
+    vlan = VLAN(vlan_id=vlan_id, name=name, created_by=created_by, site=site)
+    db.add(vlan)
+    return vlan
+
+def get_or_create_block_no_commit(db: Session, cidr: str, created_by: str | None = None, description: str | None = None) -> IPBlock:
+    block = db.query(IPBlock).filter(IPBlock.cidr == cidr).first()
+    if block:
+        return block
+    block = IPBlock(cidr=cidr, created_by=created_by, description=description)
+    db.add(block)
+    return block
+
+def create_or_get_subnet_no_commit(db: Session, cidr: str, block: IPBlock, status: SubnetStatus, created_by: str | None = None, vlan_id: int | None = None, description: str | None = None) -> Subnet:
+    sub = db.query(Subnet).filter(Subnet.cidr == cidr).first()
+    if sub:
+        return sub
+    sub = Subnet(
+        cidr=cidr,
+        status=status,
+        block_id=block.id,
+        vlan_id=vlan_id,
+        description=description,
+        created_by=created_by,
+    )
+    db.add(sub)
+    return sub
+
+def get_or_create_device_no_commit(db: Session, hostname: str, vendor: str = "cisco", model: str | None = None, mgmt_ip: str | None = None, site: str | None = None) -> Device:
+    dev = db.query(Device).filter(Device.hostname == hostname).first()
+    if dev:
+        return dev
+    dev = Device(hostname=hostname, vendor=vendor, model=model, mgmt_ip=mgmt_ip, site=site)
+    db.add(dev)
+    return dev
+
+def get_or_create_interface_no_commit(db: Session, device: Device, name: str, description: str | None = None, vlan_id: int | None = None) -> Interface:
+    itf = db.query(Interface).filter(Interface.device_id == device.id, Interface.name == name).first()
+    if itf:
+        return itf
+    itf = Interface(device_id=device.id, name=name, description=description, vlan_id=vlan_id)
+    db.add(itf)
+    return itf
+
+def add_interface_address_no_commit(db: Session, interface: Interface, ip: str, prefix: int, subnet_id: int | None = None) -> InterfaceAddress:
+    addr = InterfaceAddress(interface_id=interface.id, ip=ip, prefix=prefix, subnet_id=subnet_id)
+    db.add(addr)
+    return addr


### PR DESCRIPTION
This commit introduces a complete overhaul of the Cisco configuration import process and addresses several bugs identified during development and testing. The import workflow is now more robust, user-driven, and handles a wider range of real-world scenarios.

Key features and fixes:
- **Manual Parent Blocks**: The config upload form now includes a required field for the administrator to specify a comma-separated list of parent CIDR blocks.
- **'Unassigned' Block**: Subnets from the import that do not fit into any of the user-provided parent blocks are now placed into a default "Unassigned" block and given an 'inactive' status.
- **'Deactivated' Status for Shutdown Interfaces**: The import logic now correctly detects administratively `shutdown` interfaces and assigns the corresponding subnets a 'deactivated' status, which correctly places them on the "Churned Allocations" page.
- **VLAN Creation from Sub-interfaces**: The import logic now parses sub-interface names (e.g., `GigabitEthernet0/0.100`) to extract the VLAN ID. It then creates a corresponding VLAN in the database if one does not already exist and associates it with the imported subnet.
- **Edit and Activate Subnets**: The "Edit Allocation" page has been enhanced to allow changing a subnet's parent block. Moving a subnet from the "Unassigned" block to a valid block now automatically changes its status from 'inactive' to 'allocated'.
- **UI Indicator**: Added a visual warning on the "Edit Allocation" page for subnets that are 'inactive'.
- **Bug Fix (DB Lock)**: Refactored the import process to use non-committing CRUD functions and a single transaction to resolve a `database is locked` error with SQLite.
- **Bug Fix (Dashboard Stats)**: Fixed the main dashboard's utilization statistics to correctly include subnets with an 'imported' status in the 'used IPs' calculation.
- **Bug Fix (Shutdown Check)**: Fixed a critical `AttributeError` by replacing an incorrect attribute access with the correct `ciscoconfparse` method to check for shutdown status.
- **UX Improvement**: The import process now redirects back to the main dashboard instead of returning a raw JSON response.