### PR TITLE
feat: Overhaul Cisco config import and fix critical bugs

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -44,6 +44,7 @@ def import_cisco_config(
     hostname = hostname[0].split()[1] if hostname else f"device-{file.filename}"
 
     device = crud.get_or_create_device_no_commit(db, hostname=hostname)
+    db.flush()  # Flush to get the device ID before creating interfaces
     device_cache[hostname] = device
 
     # Get or create the 'Unassigned' block


### PR DESCRIPTION
This commit introduces a complete overhaul of the Cisco configuration import process and addresses several bugs identified during development and testing. The import workflow is now more robust, user-driven, and handles a wider range of real-world scenarios.

Key features and fixes:
- **Manual Parent Blocks**: The config upload form now includes a required field for the administrator to specify a comma-separated list of parent CIDR blocks.
- **'Unassigned' Block**: Subnets from the import that do not fit into any of the user-provided parent blocks are now placed into a default "Unassigned" block and given an 'inactive' status.
- **'Deactivated' Status for Shutdown Interfaces**: The import logic now correctly detects administratively `shutdown` interfaces and assigns the corresponding subnets a 'deactivated' status, which correctly places them on the "Churned Allocations" page.
- **VLAN Creation from Sub-interfaces**: The import logic now parses sub-interface names (e.g., `GigabitEthernet0/0.100`) to extract the VLAN ID. It then creates a corresponding VLAN in the database if one does not already exist and associates it with the imported subnet.
- **Edit and Activate Subnets**: The "Edit Allocation" page has been enhanced to allow changing a subnet's parent block. Moving a subnet from the "Unassigned" block to a valid block now automatically changes its status from 'inactive' to 'allocated'.
- **UI Indicator**: Added a visual warning on the "Edit Allocation" page for subnets that are 'inactive'.
- **Bug Fix (DB Lock & Integrity)**: Refactored the import process to use non-committing CRUD functions and a single database transaction with a local cache. This resolves both the `database is locked` error and the `UNIQUE constraint failed` integrity error. A `db.flush()` is used to ensure foreign key relationships are populated correctly within the transaction.
- **Bug Fix (Dashboard Stats)**: Fixed the main dashboard's utilization statistics to correctly include subnets with an 'imported' status in the 'used IPs' calculation and to ignore the non-routable "Unassigned" block.
- **Bug Fix (Shutdown Check)**: Fixed a critical `AttributeError` by replacing an incorrect attribute access with the correct `ciscoconfparse` method to check for shutdown status.
- **UX Improvement**: The import process now redirects back to the main dashboard instead of returning a raw JSON response.