### PR TITLE
feat: Overhaul Cisco config import with two-pass logic and bug fixes

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from ciscoconfparse import CiscoConfParse
 
 from database import get_db
-from models import SubnetStatus, User, Device, Interface, VLAN, IPBlock
+from models import SubnetStatus, User
 import crud
 from security import get_current_user
 
@@ -33,23 +33,10 @@ def import_cisco_config(
     content = file.file.read().decode(errors="ignore")
     parse = CiscoConfParse(io.StringIO(content).read().splitlines())
 
-    # --- Caching dictionaries to prevent duplicate object creation within a single transaction ---
-    device_cache: dict[str, Device] = {}
-    interface_cache: dict[str, Interface] = {}
-    vlan_cache: dict[int, VLAN] = {}
-    block_cache: dict[str, IPBlock] = {}
+    # --- First Pass: Collect all required parent objects ---
 
-    # Guess hostname
-    hostname = parse.find_lines(r"^hostname\s+")
-    hostname = hostname[0].split()[1] if hostname else f"device-{file.filename}"
-
-    device = crud.get_or_create_device_no_commit(db, hostname=hostname)
-    db.flush()  # Flush to get the device ID before creating interfaces
-    device_cache[hostname] = device
-
-    # Get or create the 'Unassigned' block
-    unassigned_block = crud.get_or_create_block_no_commit(db, "Unassigned", description="For imported subnets that do not fit into any specified parent block.")
-    block_cache["Unassigned"] = unassigned_block
+    required_parent_cidrs = set()
+    required_vlan_nums = set()
 
     # Parse parent blocks from form input
     parent_networks = []
@@ -57,36 +44,52 @@ def import_cisco_config(
         cidrs = [cidr.strip() for cidr in parent_blocks.split(",")]
         for cidr in cidrs:
             try:
-                parent_networks.append(ipaddress.ip_network(cidr))
+                net = ipaddress.ip_network(cidr)
+                parent_networks.append(net)
+                required_parent_cidrs.add(str(net))
             except ValueError:
                 raise HTTPException(status_code=400, detail=f"Invalid CIDR format: {cidr}")
 
     intfs = parse.find_objects(r"^interface\s+")
-    networks_to_process = []
     for intf in intfs:
         name = intf.text.split(None, 1)[1].strip()
+        if '.' in name:
+            try:
+                vlan_num = int(name.split('.')[-1])
+                required_vlan_nums.add(vlan_num)
+            except ValueError:
+                pass
 
-        if name in interface_cache:
-            iface = interface_cache[name]
-        else:
-            iface = crud.get_or_create_interface_no_commit(db, device, name)
-            interface_cache[name] = iface
+    # --- Creation Phase: Ensure all parent objects exist ---
+
+    hostname = parse.find_lines(r"^hostname\s+")
+    hostname = hostname[0].split()[1] if hostname else f"device-{file.filename}"
+    device = crud.get_or_create_device(db, hostname=hostname)
+
+    crud.get_or_create_block(db, "Unassigned", description="For imported subnets that do not fit into any specified parent block.")
+
+    for cidr in required_parent_cidrs:
+        crud.get_or_create_block(db, cidr, created_by=user.username)
+
+    for vlan_num in required_vlan_nums:
+        crud.get_or_create_vlan(db, vlan_id=vlan_num, created_by=user.username)
+
+    # --- Second Pass: Import the data, now that parents are guaranteed to exist ---
+
+    imported = 0
+    for intf in intfs:
+        name = intf.text.split(None, 1)[1].strip()
+        iface = crud.get_or_create_interface(db, device, name)
 
         is_shutdown = len(intf.re_search_children(r"^\s*shutdown\s*$")) > 0
 
-        # Try to parse VLAN ID from sub-interface name
         vlan_id_to_associate = None
         if '.' in name:
             try:
                 vlan_num = int(name.split('.')[-1])
-                if vlan_num in vlan_cache:
-                    vlan = vlan_cache[vlan_num]
-                else:
-                    vlan = crud.get_vlan_by_id(db, vlan_num)
-                    if not vlan:
-                        vlan = crud.create_vlan_no_commit(db, vlan_id=vlan_num, name=f"VLAN-{vlan_num}", created_by=user.username)
-                    vlan_cache[vlan_num] = vlan
-                vlan_id_to_associate = vlan.id
+                vlan = crud.get_vlan_by_id(db, vlan_num)
+                if vlan:
+                    vlan_id_to_associate = vlan.id
             except ValueError:
                 pass
 
@@ -103,46 +106,28 @@ def import_cisco_config(
                 mask = parts[3]
                 try:
                     network = ipaddress.ip_network(f"{ip}/{mask}", strict=False)
-                    networks_to_process.append({
-                        "network": network, "iface": iface, "ip": ip,
-                        "description": description, "is_shutdown": is_shutdown,
-                        "vlan_id": vlan_id_to_associate
-                    })
+
+                    assigned_parent = next((p_net for p_net in parent_networks if network.subnet_of(p_net)), None)
+
+                    status = SubnetStatus.imported
+                    if is_shutdown:
+                        status = SubnetStatus.deactivated
+                    elif assigned_parent is None:
+                        status = SubnetStatus.inactive
+
+                    parent_cidr = str(assigned_parent) if assigned_parent else "Unassigned"
+                    parent_block_obj = db.query(crud.IPBlock).filter(crud.IPBlock.cidr == parent_cidr).first()
+
+                    subnet = crud.create_or_get_subnet(
+                        db, str(network.with_prefixlen), parent_block_obj,
+                        status=status, created_by=user.username,
+                        vlan_id=vlan_id_to_associate, description=description
+                    )
+
+                    crud.add_interface_address(db, iface, ip=ip, prefix=network.prefixlen, subnet_id=subnet.id)
+                    imported += 1
+
                 except ValueError:
                     continue
 
-    imported = 0
-    if networks_to_process:
-        for net_info in networks_to_process:
-            network = net_info["network"]
-
-            assigned_parent = next((p_net for p_net in parent_networks if network.subnet_of(p_net)), None)
-
-            status = SubnetStatus.imported
-            if net_info["is_shutdown"]:
-                status = SubnetStatus.deactivated
-            elif assigned_parent is None:
-                status = SubnetStatus.inactive
-
-            parent_block_obj = None
-            if assigned_parent:
-                parent_cidr = str(assigned_parent)
-                if parent_cidr in block_cache:
-                    parent_block_obj = block_cache[parent_cidr]
-                else:
-                    parent_block_obj = crud.get_or_create_block_no_commit(db, parent_cidr, created_by=user.username)
-                    block_cache[parent_cidr] = parent_block_obj
-            else:
-                parent_block_obj = unassigned_block
-
-            subnet = crud.create_or_get_subnet_no_commit(
-                db, str(network.with_prefixlen), parent_block_obj,
-                status=status, created_by=user.username,
-                vlan_id=net_info["vlan_id"], description=net_info["description"]
-            )
-
-            crud.add_interface_address_no_commit(db, net_info["iface"], ip=net_info["ip"], prefix=network.prefixlen, subnet_id=subnet.id)
-            imported += 1
-
-    db.commit()
     return RedirectResponse(url="/", status_code=303)


### PR DESCRIPTION
This commit introduces a complete overhaul of the Cisco configuration import process, refactoring it to a more robust two-pass system. This resolves a series of database locking and integrity errors and incorporates a wide range of user-requested features to make the import process more flexible and powerful.

Key features and fixes:
- **Two-Pass Import Logic**: The import process now first parses the config to identify and pre-create all necessary parent objects (IP Blocks, VLANs). A second pass then creates the subnets and associates them with their parent objects, which are guaranteed to exist. This resolves all previously encountered database transaction errors.
- **Manual Parent Blocks**: The config upload form now includes a required field for the administrator to specify a comma-separated list of parent CIDR blocks.
- **'Unassigned' Block**: Subnets from the import that do not fit into any of the user-provided parent blocks are placed into a default "Unassigned" block and given an 'inactive' status.
- **VLAN Creation from Sub-interfaces**: The import logic now parses sub-interface names to extract VLAN IDs and creates corresponding VLANs in the database if they don't exist. A `get_or_create_vlan` helper was added to `crud.py`.
- **'Deactivated' Status for Shutdown Interfaces**: The import logic now correctly detects administratively `shutdown` interfaces and assigns the corresponding subnets a 'deactivated' status.
- **Edit and Activate Subnets**: The "Edit Allocation" page has been enhanced to allow changing a subnet's parent block. Moving a subnet from the "Unassigned" block to a valid block now automatically changes its status from 'inactive' to 'allocated'.
- **UI/UX Improvements**:
  - The import process now redirects to the dashboard instead of returning a JSON response.
  - A visual warning is added to the "Edit Allocation" page for inactive subnets.
  - The config upload form has been restyled for better usability.
- **Dashboard Statistics Fix**: The dashboard's utilization statistics now correctly include 'imported' subnets and ignore the 'Unassigned' block.