### PR TITLE
feat: Overhaul Cisco config import and fix critical bugs

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,12 +144,15 @@ def allocate_ip_action(
             vlan_id=vlan_id,
             description=final_description
         )
+        return RedirectResponse("/dashboard/allocate_ip?success=1", status_code=303)
     except HTTPException as e:
-        # You can pass the error message to the template
-        # For now, just re-raise
-        raise e
-
-    return RedirectResponse("/dashboard/allocate_ip", status_code=303)
+        # Handle exceptions raised by allocate_subnet (e.g., no available space)
+        error_message = e.detail
+        return RedirectResponse(f"/dashboard/allocate_ip?error={error_message}", status_code=303)
+    except Exception as e:
+        # Handle other unexpected errors (like the IntegrityError)
+        error_message = f"An unexpected error occurred: {e}"
+        return RedirectResponse(f"/dashboard/allocate_ip?error={error_message}", status_code=303)
 
 @app.get("/login", response_class=HTMLResponse)
 def login_page(request: Request):

--- a/ip_allocator.py
+++ b/ip_allocator.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from fastapi import HTTPException
 from typing import Optional
 
+import crud
 from models import IPBlock, Subnet, User, SubnetStatus
 
 def allocate_subnet(
@@ -39,18 +40,15 @@ def allocate_subnet(
 
         # If it doesn't overlap, we've found our available subnet
         if not is_overlapping:
-            new_allocation = Subnet(
+            return crud.create_or_get_subnet(
+                db,
                 cidr=str(candidate_subnet),
+                block=block,
                 status=SubnetStatus.allocated,
                 vlan_id=vlan_id,
                 description=description,
                 created_by=user.username,
-                block_id=block.id,
             )
-            db.add(new_allocation)
-            db.commit()
-            db.refresh(new_allocation)
-            return new_allocation
 
     # If the loop completes, no available subnet was found
     raise HTTPException(status_code=400, detail="No available subnets of this size in the block")

--- a/templates/allocate_ip.html
+++ b/templates/allocate_ip.html
@@ -7,6 +7,19 @@
   <p class="text-slate-500">Automatically find and allocate the next available subnet from a parent block.</p>
 </div>
 
+{% if request.query_params.error %}
+<div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+  <strong class="font-bold">Error:</strong>
+  <span class="block sm:inline">{{ request.query_params.error }}</span>
+</div>
+{% endif %}
+{% if request.query_params.success %}
+<div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+  <strong class="font-bold">Success!</strong>
+  <span class="block sm:inline">New subnet allocated.</span>
+</div>
+{% endif %}
+
 <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6 mb-8">
     <form method="post" action="/allocate" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
 


### PR DESCRIPTION
This commit introduces a complete overhaul of the Cisco configuration import process, refactoring it to a more robust two-pass system. This resolves a series of database locking and integrity errors and incorporates a wide range of user-requested features to make the import process more flexible and powerful.

Key features and fixes:
- **Two-Pass Import Logic**: The import process now first parses the config to identify and pre-create all necessary parent objects (IP Blocks, VLANs). A second pass then creates the subnets and associates them with their parent objects, which are guaranteed to exist. This resolves all previously encountered database transaction errors.
- **Manual Parent Blocks**: The config upload form now includes a required field for the administrator to specify a comma-separated list of parent CIDR blocks.
- **'Unassigned' Block**: Subnets from the import that do not fit into any of the user-provided parent blocks are placed into a default "Unassigned" block and given an 'inactive' status.
- **VLAN Creation from Sub-interfaces**: The import logic now parses sub-interface names and uses their descriptions as the VLAN name, with a sensible fallback. A `get_or_create_vlan` helper was added to `crud.py`.
- **'Deactivated' Status for Shutdown Interfaces**: The import logic now correctly detects administratively `shutdown` interfaces and assigns the corresponding subnets a 'deactivated' status.
- **Edit and Activate Subnets**: The "Edit Allocation" page has been enhanced to allow changing a subnet's parent block. Moving a subnet from the "Unassigned" block to a valid block now automatically changes its status from 'inactive' to 'allocated'.
- **UI/UX Improvements**:
  - The import process now redirects to the dashboard instead of returning a JSON response.
  - The allocation page now displays user-friendly error and success messages.
  - A visual warning is added to the "Edit Allocation" page for inactive subnets.
- **Bug Fix (Allocation Integrity)**: The IP allocation logic in `ip_allocator.py` now uses `crud.create_or_get_subnet` to prevent duplicate subnet creation.
- **Bug Fix (Dashboard Stats)**: The dashboard's utilization statistics now correctly include 'imported' subnets and ignore the 'Unassigned' block.