### PR TITLE
Fix AttributeError in Cisco config import

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -68,7 +68,7 @@ def import_config(
 
 
 def handle_cisco_import(db: Session, user: User, content: str, parent_networks: list, filename: str):
-    parse = CiscoConfParse(io.StringIO(content).splitlines(), factory=True)
+    parse = CiscoConfParse(content.splitlines(), factory=True)
 
     required_client_names = set()
     interface_to_description = {}


### PR DESCRIPTION
This commit fixes an `AttributeError` that occurred when importing a Cisco configuration file. The error was caused by calling `splitlines()` on a `StringIO` object instead of the content string itself.

This commit corrects the method call to ensure the config file is parsed correctly.