### PR TITLE
Feat: Enhance dashboard and fix IP filtering bug

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,55 +4,57 @@
 
 {% block content %}
 <div class="container mx-auto px-4 py-6">
-    <!-- Stats Cards -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-        <div class="bg-white rounded-lg shadow p-6 flex items-center justify-between">
-            <div>
-                <p class="text-sm font-medium text-gray-500">Total IP Blocks</p>
-                <p class="text-2xl font-bold">{{ block_stats|length }}</p>
+    <div class="sticky top-0 z-10 bg-slate-50 py-4">
+        <!-- Stats Cards -->
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+            <div class="bg-white rounded-lg shadow p-6 flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-gray-500">Total IP Blocks</p>
+                    <p class="text-2xl font-bold">{{ block_stats|length }}</p>
+                </div>
+                <div class="bg-blue-100 text-blue-600 rounded-full p-3">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
+                </div>
             </div>
-            <div class="bg-blue-100 text-blue-600 rounded-full p-3">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" /></svg>
+            <div class="bg-white rounded-lg shadow p-6 flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-gray-500">Total VLANs</p>
+                    <p class="text-2xl font-bold">{{ vlan_count }}</p>
+                </div>
+                <div class="bg-purple-100 text-purple-600 rounded-full p-3">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 002 2h4a2 2 0 002-2V7m-6 0h4" /></svg>
+                </div>
+            </div>
+            <div class="bg-white rounded-lg shadow p-6 flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-gray-500">Active Clients</p>
+                    <p class="text-2xl font-bold">{{ client_count }}</p>
+                </div>
+                <div class="bg-green-100 text-green-600 rounded-full p-3">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" /></svg>
+                </div>
+            </div>
+            <div class="bg-white rounded-lg shadow p-6 flex items-center justify-between">
+                <div>
+                    <p class="text-sm font-medium text-gray-500">Total Devices</p>
+                    <p class="text-2xl font-bold">0</p> <!-- Placeholder -->
+                </div>
+                <div class="bg-red-100 text-red-600 rounded-full p-3">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" /></svg>
+                </div>
             </div>
         </div>
-        <div class="bg-white rounded-lg shadow p-6 flex items-center justify-between">
-            <div>
-                <p class="text-sm font-medium text-gray-500">Total VLANs</p>
-                <p class="text-2xl font-bold">{{ vlan_count }}</p>
-            </div>
-            <div class="bg-purple-100 text-purple-600 rounded-full p-3">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7v8a2 2 0 002 2h4a2 2 0 002-2V7m-6 0h4" /></svg>
-            </div>
-        </div>
-        <div class="bg-white rounded-lg shadow p-6 flex items-center justify-between">
-            <div>
-                <p class="text-sm font-medium text-gray-500">Active Clients</p>
-                <p class="text-2xl font-bold">{{ client_count }}</p>
-            </div>
-            <div class="bg-green-100 text-green-600 rounded-full p-3">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" /></svg>
-            </div>
-        </div>
-        <div class="bg-white rounded-lg shadow p-6 flex items-center justify-between">
-            <div>
-                <p class="text-sm font-medium text-gray-500">Total Devices</p>
-                <p class="text-2xl font-bold">0</p> <!-- Placeholder -->
-            </div>
-            <div class="bg-red-100 text-red-600 rounded-full p-3">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01" /></svg>
-            </div>
-        </div>
-    </div>
 
-    <!-- Search Bar -->
-    <div class="mb-8">
-        <form action="/dashboard/search" method="get" class="relative">
-            <input type="search" name="query" placeholder="Search for IPs, Subnets, Clients, VLANs..."
-                   class="w-full pl-10 pr-4 py-3 border rounded-full text-lg focus:ring-indigo-500 focus:border-indigo-500">
-            <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
-            </div>
-        </form>
+        <!-- Search Bar -->
+        <div class="mb-8">
+            <form action="/dashboard/search" method="get" class="relative">
+                <input type="search" name="query" placeholder="Search for IPs, Subnets, Clients, VLANs..."
+                       class="w-full pl-10 pr-4 py-3 border rounded-full text-lg focus:ring-indigo-500 focus:border-indigo-500">
+                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+                </div>
+            </form>
+        </div>
     </div>
 
     <!-- Utilization & Recent Allocations -->
@@ -62,36 +64,71 @@
             <h2 class="text-lg font-semibold mb-4">IP Block Utilization</h2>
             <div class="space-y-4">
                 {% for stat in block_stats %}
-                <div class="py-4 border-b border-gray-200 last:border-b-0">
-                    <div class="flex justify-between items-center mb-2">
-                        <a href="{{ url_for('edit_block_page', block_id=stat.block.id) }}" class="text-base font-medium text-gray-800 hover:text-indigo-600">
-                            {{ stat.block.cidr }} - <span class="text-sm text-gray-500">{{ stat.block.description or 'No description' }}</span>
-                        </a>
-                        <span class="text-sm font-medium text-gray-700">{{ "%.2f"|format(stat.utilization) }}%</span>
-                    </div>
-                    <div class="w-full bg-gray-200 rounded-full h-2.5 mb-2">
-                        <div class="bg-gray-900 h-2.5 rounded-full" style="width: {{ stat.utilization }}%"></div>
-                    </div>
-                    <div class="text-xs flex justify-between text-gray-500">
-                        <span>Used: {{ stat.used_ips|int }}</span>
-                        <span>Free: {{ stat.free_ips|int }}</span>
-                        <span>Total: {{ stat.total_ips|int }}</span>
-                    </div>
-                    {% if stat.clients %}
-                    <details class="mt-2">
-                        <summary class="cursor-pointer text-xs text-gray-500 mb-1">
-                            Active Clients ({{ stat.clients|length }})
-                        </summary>
-                        <div class="flex flex-wrap gap-2 pt-2">
-                            {% for client in stat.clients|sort(attribute='name') %}
-                            <a href="{{ url_for('client_detail_page', client_id=client.id) }}" class="text-xs bg-gray-200 text-gray-800 px-2 py-1 rounded-full hover:bg-gray-300">
-                                {{ client.name }}
-                            </a>
-                            {% endfor %}
+                <details class="py-4 border-b border-gray-200 last:border-b-0 group">
+                    <summary class="flex justify-between items-center cursor-pointer">
+                        <div class="flex-grow">
+                            <div class="flex justify-between items-center mb-2">
+                                <span class="text-base font-medium text-gray-800 group-hover:text-indigo-600">
+                                    {{ stat.block.cidr }} - <span class="text-sm text-gray-500">{{ stat.block.description or 'No description' }}</span>
+                                </span>
+                                <span class="text-sm font-medium text-gray-700">{{ "%.2f"|format(stat.utilization) }}%</span>
+                            </div>
+                            <div class="w-full bg-gray-200 rounded-full h-2.5 mb-2">
+                                <div class="bg-gray-900 h-2.5 rounded-full" style="width: {{ stat.utilization }}%"></div>
+                            </div>
+                            <div class="text-xs flex justify-between text-gray-500">
+                                <span>Used: {{ stat.used_ips|int }}</span>
+                                <span>Free: {{ stat.free_ips|int }}</span>
+                                <span>Total: {{ stat.total_ips|int }}</span>
+                            </div>
                         </div>
-                    </details>
-                    {% endif %}
-                </div>
+                        <div class="ml-4 text-gray-500 group-open:rotate-90 transition-transform">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                                <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                            </svg>
+                        </div>
+                    </summary>
+                    <div class="mt-4 pt-4 border-t">
+                        <div class="flex justify-between items-center mb-2">
+                            <h4 class="text-sm font-semibold">Subnets in this Block</h4>
+                            <a href="{{ url_for('edit_block_page', block_id=stat.block.id) }}" class="text-xs text-indigo-600 hover:underline">Edit Block</a>
+                        </div>
+                        <table class="min-w-full text-sm">
+                            <thead class="bg-gray-100">
+                                <tr>
+                                    <th class="text-left p-2">CIDR</th>
+                                    <th class="text-left p-2">Description</th>
+                                    <th class="text-left p-2">Status</th>
+                                    <th class="text-left p-2">Client</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for subnet in stat.block.subnets|sort(attribute='cidr') %}
+                                <tr class="border-b last:border-b-0">
+                                    <td class="p-2 font-mono">{{ subnet.cidr }}</td>
+                                    <td class="p-2">{{ subnet.description }}</td>
+                                    <td class="p-2">{{ subnet.status.name }}</td>
+                                    <td class="p-2">{{ subnet.client.name if subnet.client else 'N/A' }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        {% if stat.clients %}
+                        <details class="mt-4">
+                            <summary class="cursor-pointer text-xs text-gray-500 mb-1">
+                                Active Clients ({{ stat.clients|length }})
+                            </summary>
+                            <div class="flex flex-wrap gap-2 pt-2">
+                                {% for client in stat.clients|sort(attribute='name') %}
+                                <a href="{{ url_for('client_detail_page', client_id=client.id) }}" class="text-xs bg-gray-200 text-gray-800 px-2 py-1 rounded-full hover:bg-gray-300">
+                                    {{ client.name }}
+                                </a>
+                                {% endfor %}
+                            </div>
+                        </details>
+                        {% endif %}
+                    </div>
+                </details>
                 {% else %}
                 <p class="text-center text-gray-500">No IP blocks to display.</p>
                 {% endfor %}


### PR DESCRIPTION
This commit introduces several enhancements to the dashboard and fixes a bug related to IP address filtering during configuration import, based on user feedback.

Dashboard Enhancements:
- Added a display for the number of used, free, and total IPs for each block to provide more detailed utilization information.
- Made the client lists for each block collapsible for a cleaner user interface.
- Made the dashboard header (stats cards and search bar) sticky so it remains at the top of the page when scrolling.
- Made the IP block utilization cards expandable to show a detailed table of all subnets within that block.

Bug Fixes:
- Implemented a subnet ignore list in the configuration import logic. This prevents specified subnets (e.g., 10.128.128.0/24) from being imported and incorrectly affecting block utilization statistics.