### PR TITLE
Feat: Display admin warning on UI

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -12,6 +12,11 @@
         <a href="/" class="text-2xl font-bold tracking-wider text-gray-800">EDEM<span class="text-blue-500">ROBIN</span></a>
     </div>
     <h2 class="text-center text-gray-600 mb-4">Login to your account</h2>
+    {% if startup_message %}
+    <div class="bg-yellow-50 border border-yellow-200 text-yellow-800 p-3 rounded-lg mb-4 text-sm" role="alert">
+      <span class="font-bold">⚠️ Security Warning:</span> {{ startup_message }}
+    </div>
+    {% endif %}
     <form method="post" action="/login" class="space-y-4">
     {% if error %}
     <div class="bg-red-50 border border-red-200 text-red-700 p-2 rounded mb-4">{{ error }}</div>


### PR DESCRIPTION
This commit changes the behavior of the "Default admin created" warning. Instead of being printed to the console on startup, the message is now stored in the application state and displayed as a prominent warning on the login page.

This improves the visibility of this important security warning. The message is cleared from the state after being displayed once, so it doesn't appear on subsequent visits to the login page.