### PR TITLE
Fix: Add missing import in routes_dashboard

### DIFF
--- a/routes_dashboard.py
+++ b/routes_dashboard.py
@@ -3,6 +3,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 from fastapi.templating import Jinja2Templates
 from typing import Optional
+import ipaddress
 
 import crud, models
 from database import get_db


### PR DESCRIPTION
This commit fixes a `NameError` that occurred when creating a NAT IP. The error was caused by a missing `import ipaddress` statement in `routes_dashboard.py`.