### PR TITLE
fix: Remove all user.level references from templates

### DIFF
--- a/templates/admin_clients.html
+++ b/templates/admin_clients.html
@@ -14,7 +14,7 @@
 </div>
 {% endif %}
 
-{% if user.level >= 2 %}
+{% if user.can_manage_clients or user.is_admin %}
 <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6 mb-8">
     <h2 class="text-lg font-semibold text-slate-700 mb-4">Add New Client</h2>
     <form method="post" action="/admin/clients/create" class="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -44,7 +44,7 @@
 
 <form action="/admin/clients/bulk_action" method="post">
 <div class="bg-white rounded-lg shadow-sm border border-slate-200 overflow-x-auto">
-  {% if user.level >= 2 %}
+  {% if user.can_manage_clients or user.is_admin %}
   <div class="p-4 flex items-center gap-4 border-b border-slate-200">
       <label for="bulk_action" class="text-sm font-medium text-slate-600">Bulk Action:</label>
       <select name="action" id="bulk_action" class="border-slate-300 rounded-md shadow-sm text-sm focus:border-sky-500 focus:ring-sky-500">
@@ -57,18 +57,18 @@
   <table class="min-w-full">
     <thead class="bg-slate-50">
       <tr>
-        {% if user.level >= 2 %}<th class="p-4"><input type="checkbox" onclick="toggleAll(this)"></th>{% endif %}
+        {% if user.can_manage_clients or user.is_admin %}<th class="p-4"><input type="checkbox" onclick="toggleAll(this)"></th>{% endif %}
         <th class="text-left p-4 text-sm font-semibold text-slate-600">Client Name</th>
         <th class="text-left p-4 text-sm font-semibold text-slate-600">Status</th>
         <th class="text-left p-4 text-sm font-semibold text-slate-600">Subnets Assigned</th>
         <th class="text-left p-4 text-sm font-semibold text-slate-600">Created At</th>
-        {% if user.level >= 2 %}<th class="text-left p-4 text-sm font-semibold text-slate-600">Actions</th>{% endif %}
+        {% if user.can_manage_clients or user.is_admin %}<th class="text-left p-4 text-sm font-semibold text-slate-600">Actions</th>{% endif %}
       </tr>
     </thead>
     <tbody class="divide-y divide-slate-200" id="client-table-body">
       {% for client in clients %}
       <tr class="hover:bg-slate-50">
-        {% if user.level >= 2 %}<td class="p-4"><input type="checkbox" name="client_ids" value="{{ client.id }}"></td>{% endif %}
+        {% if user.can_manage_clients or user.is_admin %}<td class="p-4"><input type="checkbox" name="client_ids" value="{{ client.id }}"></td>{% endif %}
         <td class="p-4 font-semibold text-slate-700">
           <a href="/clients/{{ client.id }}" class="text-sky-600 hover:underline">{{ client.name }}</a>
         </td>
@@ -81,7 +81,7 @@
         </td>
         <td class="p-4 text-sm text-slate-600">{{ client.subnets|length }}</td>
         <td class="p-4 text-sm text-slate-500">{{ client.created_at.strftime("%Y-%m-%d %H:%M:%S") }}</td>
-        {% if user.level >= 2 %}
+        {% if user.can_manage_clients or user.is_admin %}
         <td class="p-4 text-sm space-x-4 whitespace-nowrap">
             <form action="/admin/clients/{{ client.id }}/toggle_status" method="post" class="inline-block">
                 <button type="submit" class="text-blue-600 hover:underline font-semibold">

--- a/templates/index.html
+++ b/templates/index.html
@@ -110,7 +110,7 @@
           {% endif %}
         </td>
         <td class="p-4 text-sm whitespace-nowrap">
-          {% if alloc.status.name == 'inactive' and user.level >= 2 %}
+          {% if alloc.status.name == 'inactive' and (user.can_manage_allocations or user.is_admin) %}
             <form action="/dashboard/allocations/{{ alloc.id }}/activate" method="post" class="inline-block">
                 <button type="submit" class="text-green-600 hover:underline font-semibold">Activate</button>
             </form>

--- a/templates/nat_ips.html
+++ b/templates/nat_ips.html
@@ -7,7 +7,7 @@
     <h1 class="text-2xl font-bold text-slate-700">NAT IPs</h1>
     <p class="text-slate-500">A list of all NAT IPs, either imported or manually created.</p>
   </div>
-  {% if user.level >= 2 %}
+  {% if user.can_manage_nat or user.is_admin %}
   <a href="/dashboard/add_nat_ip" class="bg-slate-800 text-white font-semibold rounded-lg px-4 py-2 text-sm hover:bg-slate-700 transition whitespace-nowrap">
     Add NAT IP
   </a>


### PR DESCRIPTION
- Systematically removes all remaining references to the deprecated `user.level` attribute from all templates.
- Replaces the old level-based conditional logic for showing UI elements with checks for the new granular permissions (e.g., `user.can_manage_clients`, `user.can_manage_nat`).
- This resolves multiple `jinja2.exceptions.UndefinedError` errors that were causing the application to crash when rendering various pages.
- This is a comprehensive fix for all templates identified by a codebase search.