### PR TITLE
fix: Correct dependency injection for config import

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -17,15 +17,14 @@ router = APIRouter(prefix="/import", tags=["Import"])
 
 from utils import parse_mikrotik_config
 
-@router.post("/config", dependencies=[Depends(permission_required("can_upload_config"))])
+@router.post("/config")
 def import_config(
-    request: Request,
+    user: User = Depends(permission_required("can_upload_config")),
     file: UploadFile = File(...),
     config_type: str = Form(...),
     parent_blocks: str = Form(""),
     db: Session = Depends(get_db),
 ):
-    user = get_current_user(request, db)
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file uploaded.")
 


### PR DESCRIPTION
- Refactors the `import_config` route to move the permission check from the decorator's `dependencies` list into the function signature as a direct dependency.
- This simplifies FastAPI's dependency injection process for `multipart/form-data` requests that also require authentication, resolving a `422 Unprocessable Entity` error.
- Removes the now-redundant `get_current_user` call from the function body.