### PR TITLE
fix: Prevent KeyError during MikroTik config import

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -178,6 +178,10 @@ def handle_mikrotik_import(db: Session, user: User, content: str, parent_network
 
     for addr in parsed_data.get('addresses', []):
         try:
+            # Skip addresses that don't have an interface specified
+            if 'interface' not in addr or not addr['interface']:
+                continue
+
             iface_addr = ipaddress.ip_interface(addr['address'])
             network = iface_addr.network
 


### PR DESCRIPTION
- Adds a check to the `handle_mikrotik_import` function to verify the existence of the 'interface' key before accessing it.
- This prevents the application from crashing with a `KeyError` when processing a MikroTik IP address entry that is not associated with an interface.
- The import process will now safely skip such entries and continue.