### PR TITLE
feat: Enhance Mikrotik configuration import

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -169,7 +169,7 @@ def handle_mikrotik_import(db: Session, user: User, content: str, parent_network
     if not parsed_data:
         return
 
-    # --- Pre-process and cache VLANs for efficient lookup ---
+    # --- Step 1: Pre-process and cache VLANs, DHCP Pools, and Servers ---
     vlans_by_name = {}
     vlans_by_id = {}
     for vlan_data in parsed_data.get('vlans', []):
@@ -178,23 +178,30 @@ def handle_mikrotik_import(db: Session, user: User, content: str, parent_network
             name = vlan_data.get('name')
             if not name or not vlan_id:
                 continue
-
             vlan_db = crud.get_or_create_vlan(db, vlan_id=vlan_id, name=name, created_by=user.username)
             vlans_by_name[name] = vlan_db
             vlans_by_id[vlan_id] = vlan_db
         except (ValueError, TypeError):
             continue
 
+    pools_by_name = {pool.get('name'): pool for pool in parsed_data.get('pools', [])}
+    interface_to_pool_info = {}
+    for server in parsed_data.get('dhcp_servers', []):
+        pool_name = server.get('address-pool')
+        iface_name = server.get('interface')
+        if pool_name in pools_by_name and iface_name:
+            pool_ranges = pools_by_name[pool_name].get('ranges')
+            if pool_ranges:
+                interface_to_pool_info[iface_name] = f"DHCP Pool: {pool_ranges}"
+
     hostname = next((item.get('name') for item in parsed_data.get('system', []) if item.get('name')), f"mikrotik-device-{filename}")
     device = crud.get_or_create_device(db, hostname=hostname)
 
-    # The logic now creates clients inside the address loop based on the final description.
-    # The pre-creation of clients based on comments is no longer needed.
-
+    # --- Step 2: Process IP Addresses and create Subnets ---
     for addr in parsed_data.get('addresses', []):
         try:
             iface_name = addr.get('interface')
-            if not iface_name:
+            if not iface_name or not addr.get('address'):
                 continue
 
             iface_addr = ipaddress.ip_interface(addr['address'])
@@ -205,37 +212,29 @@ def handle_mikrotik_import(db: Session, user: User, content: str, parent_network
 
             iface = crud.get_or_create_interface(db, device, iface_name)
 
-            # --- Advanced VLAN Matching Logic ---
-            linked_vlan_object = None
-            # Strategy 1: Direct name match
-            if iface_name in vlans_by_name:
-                linked_vlan_object = vlans_by_name[iface_name]
-            # Strategy 2: Numeric match from interface name
-            else:
+            linked_vlan_object = vlans_by_name.get(iface_name)
+            if not linked_vlan_object:
                 match = re.search(r'\d+', iface_name)
                 if match:
                     try:
                         num = int(match.group(0))
-                        if num in vlans_by_id:
-                            linked_vlan_object = vlans_by_id[num]
+                        linked_vlan_object = vlans_by_id.get(num)
                     except (ValueError, KeyError):
-                        pass # No matching vlan_id found
+                        pass
 
-            # --- Description and Client Logic ---
-            comment = addr.get('comment', '')
-            description = comment
+            base_comment = addr.get('comment', '')
+            description = base_comment
             if not description:
-                if linked_vlan_object:
-                    description = linked_vlan_object.name
-                else:
-                    description = iface_name
+                description = linked_vlan_object.name if linked_vlan_object else iface_name
 
-            # If no meaningful description could be found, skip this entry
+            pool_info = interface_to_pool_info.get(iface_name)
+            if pool_info:
+                description = f"{description} ({pool_info})" if description else pool_info
+
             if not description:
                 continue
 
-            # Ensure a client exists for this description
-            client = crud.get_or_create_client(db, name=description, is_active=False)
+            client = crud.get_or_create_client(db, name=base_comment or description, is_active=False)
 
             is_disabled = addr.get('disabled') == 'true'
             assigned_parent = next((p_net for p_net in parent_networks if network.subnet_of(p_net)), None)
@@ -247,31 +246,46 @@ def handle_mikrotik_import(db: Session, user: User, content: str, parent_network
                 subnet = crud.create_or_get_subnet(
                     db, str(network.with_prefixlen), parent_block_obj,
                     status=status, created_by=user.username,
-                    client_id=client.id if client else None,
+                    client_id=client.id,
                     description=description,
                     vlan_id=linked_vlan_object.id if linked_vlan_object else None
                 )
                 crud.add_interface_address(db, iface, ip=str(iface_addr.ip), prefix=network.prefixlen, subnet_id=subnet.id)
-        except ValueError:
+        except (ValueError, TypeError):
             continue
 
+    # --- Step 3: Process NAT Rules ---
     for nat_rule in parsed_data.get('nat_rules', []):
-        if nat_rule.get('action') == 'src-nat' and 'to-addresses' in nat_rule:
-            client_cidr = nat_rule.get('src-address')
-            if not client_cidr: continue
+        if nat_rule.get('action') != 'src-nat' or 'to-addresses' not in nat_rule:
+            continue
 
-            # Find client based on the source address of the NAT rule
-            client = None
-            for addr in parsed_data['addresses']:
-                if addr['address'] == client_cidr:
-                    if addr.get('comment'):
-                        client = crud.get_client_by_name(db, addr['comment'])
-                    break
+        client = None
+        nat_description = nat_rule.get('comment', "Imported from MikroTik NAT")
 
-            if client:
-                try:
-                    nat_ip_cidr = f"{nat_rule['to-addresses']}/32"
-                    if not db.query(NatIp).filter_by(ip_address=nat_ip_cidr).first():
-                        crud.create_nat_ip(db, ip_address=nat_ip_cidr, client_id=client.id, description="Imported from MikroTik NAT")
-                except Exception:
-                    db.rollback()
+        if nat_rule.get('comment'):
+            match = re.search(r'\[([^\]]+)\]', nat_rule.get('comment'))
+            if match:
+                client_name = match.group(1)
+                client = crud.get_or_create_client(db, name=client_name, is_active=False)
+
+        if not client and nat_rule.get('src-address'):
+            try:
+                nat_network = ipaddress.ip_network(nat_rule['src-address'], strict=False)
+                # This could be improved by querying subnets more efficiently
+                subnets = db.query(Subnet).filter(Subnet.client_id != None).all()
+                for subnet in subnets:
+                    subnet_network = ipaddress.ip_network(subnet.cidr, strict=False)
+                    if nat_network == subnet_network or nat_network.subnet_of(subnet_network):
+                        client = crud.get_client_by_id(db, subnet.client_id)
+                        if client:
+                            break
+            except (ValueError, TypeError):
+                pass
+
+        if client:
+            try:
+                nat_ip_cidr = f"{nat_rule['to-addresses']}/32"
+                if not db.query(NatIp).filter_by(ip_address=nat_ip_cidr).first():
+                    crud.create_nat_ip(db, ip_address=nat_ip_cidr, client_id=client.id, description=nat_description)
+            except Exception:
+                db.rollback()

--- a/utils.py
+++ b/utils.py
@@ -60,50 +60,69 @@ def parse_mikrotik_config(config_text: str):
     """
     Parses a MikroTik RouterOS configuration file to extract detailed information
     about interfaces, IP addresses, VLANs, NAT rules, and routes.
+    Handles multi-line commands and properties with hyphens.
 
     Returns a dictionary with structured data.
     """
-    # Regex to find property="value" or property=value pairs
-    prop_re = re.compile(r'(\w+)=(?:"([^"]*)"|([^ ]+))')
+    # Regex to find property="value" or property=value pairs. Handles hyphens in keys.
+    prop_re = re.compile(r'([\w-]+)=(?:"([^"]*)"|([^ ]+))')
 
     data = {
-        "vlans": [], "addresses": [], "nat_rules": [],
+        "vlans": [], "addresses": [], "nat_rules": [], "pools": [], "dhcp_servers": [],
         "routes": [], "vrfs": [], "comments": {}
     }
     current_section = None
-    has_content = False  # Flag to track if any data is parsed
+    has_content = False
 
+    # Pre-process to handle multi-line commands ending with '\'
+    processed_lines = []
+    buffer = ""
     for line in config_text.splitlines():
-        line = line.strip()
+        stripped_line = line.strip()
+        if not stripped_line:
+            continue
+        if stripped_line.endswith('\\'):
+            buffer += stripped_line[:-1].strip() + " "
+        else:
+            buffer += stripped_line
+            processed_lines.append(buffer)
+            buffer = ""
+    if buffer:
+        processed_lines.append(buffer)
+
+    for line in processed_lines:
         if not line or line.startswith('#'):
             continue
 
         if line.startswith('/'):
-            current_section = line.split('/')[1].strip()
+            # Handles sections like /ip address, /ip firewall nat, etc.
+            # Also handles deeper sections like /ip dhcp-server network
+            current_section = ' '.join(line.split('/')[1:]).strip()
             continue
 
         if line.startswith("add"):
             has_content = True
-            # Correctly parse properties
-            matches = prop_re.findall(line)
+            # Correctly parse properties from the part of the string after "add"
+            prop_string = line[3:].strip()
+            matches = prop_re.findall(prop_string)
             props = {key: val_quoted or val_unquoted for key, val_quoted, val_unquoted in matches}
 
-            if current_section == "ip address" and "address" in props:
-                # Ensure comment is a simple string, not a list/tuple
-                comment = props.get('comment', '')
-                props['comment'] = comment.strip('"') if isinstance(comment, str) else ''
+            if current_section == "interface vlan":
+                data["vlans"].append(props)
+            elif current_section == "ip address":
                 data["addresses"].append(props)
-
             elif current_section == "ip firewall nat":
                 data["nat_rules"].append(props)
+            elif current_section == "ip pool":
+                data["pools"].append(props)
+            elif current_section == "ip dhcp-server":
+                data["dhcp_servers"].append(props)
             elif current_section == "ip route":
                 data["routes"].append(props)
             elif current_section == "ip vrf":
                 data["vrfs"].append(props)
-            elif current_section == "interface vlan":
-                data["vlans"].append(props)
 
-    # Return None if no relevant content was found
+
     if not has_content:
         return None
 


### PR DESCRIPTION
This commit significantly enhances the Mikrotik configuration import functionality to correctly handle VLANs, descriptions, DHCP, and NAT rules.

The key changes are:
- The Mikrotik parser in `utils.py` has been updated to handle property keys with hyphens (e.g., `vlan-id`), multi-line commands, and to parse `/ip pool` and `/ip dhcp-server` sections.
- The import logic in `routes_import.py` has been refactored to process the newly parsed data. It now correctly associates VLANs with subnets, enriches subnet descriptions with DHCP pool information, and uses a more robust method for linking NAT rules to clients based on comments or source addresses.

These changes address the issue where VLAN and description information was not being correctly imported from Mikrotik configuration files.