### PR TITLE
fix: Correct NameError in Mikrotik import

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -10,7 +10,7 @@ from ciscoconfparse import CiscoConfParse
 IGNORED_SUBNETS = ["10.128.128.0/24"]
 
 from database import get_db
-from models import SubnetStatus, User, IPBlock, NatIp
+from models import SubnetStatus, User, IPBlock, NatIp, Subnet
 import crud
 from security import get_current_user, permission_required
 


### PR DESCRIPTION
This commit fixes a `NameError` that occurred during the Mikrotik configuration import process. The `Subnet` model was not imported in `routes_import.py`, which caused the application to crash when processing NAT rules.

This fix adds the missing import statement, resolving the error.