### PR TITLE
fix: Correct AttributeError in Mikrotik import

### DIFF
--- a/routes_import.py
+++ b/routes_import.py
@@ -276,7 +276,7 @@ def handle_mikrotik_import(db: Session, user: User, content: str, parent_network
                 for subnet in subnets:
                     subnet_network = ipaddress.ip_network(subnet.cidr, strict=False)
                     if nat_network == subnet_network or nat_network.subnet_of(subnet_network):
-                        client = crud.get_client_by_id(db, subnet.client_id)
+                        client = crud.get_client(db, subnet.client_id)
                         if client:
                             break
             except (ValueError, TypeError):


### PR DESCRIPTION
This commit fixes an `AttributeError` that occurred during the Mikrotik configuration import process. An incorrect function name (`get_client_by_id`) was used to retrieve a client from the database.

This fix replaces the incorrect function call with the correct one (`get_client`), resolving the error.