### PR TITLE
feat: Add search functionality to NAT, VLAN, and Churned pages

### DIFF
--- a/templates/add_vlan.html
+++ b/templates/add_vlan.html
@@ -25,6 +25,18 @@
     </form>
 </div>
 
+<!-- Search and List Header -->
+<div class="mb-4 mt-8 flex justify-between items-center">
+    <h2 class="text-lg font-semibold text-slate-700">Existing VLANs</h2>
+    <form action="/dashboard/add_vlan" method="get" class="flex items-center space-x-2">
+        <input type="text" name="query" value="{{ query or '' }}" placeholder="Search by ID or Name..." class="w-full md:w-auto px-3 py-2 border border-slate-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 transition text-sm">
+        <button type="submit" class="bg-sky-600 text-white font-semibold rounded-lg px-3 py-2 text-sm hover:bg-sky-500 transition">Search</button>
+        {% if query %}
+        <a href="/dashboard/add_vlan" class="text-sm text-slate-500 hover:text-slate-700 hover:underline">Clear</a>
+        {% endif %}
+    </form>
+</div>
+
 <div class="bg-white rounded-lg shadow-sm border border-slate-200 overflow-x-auto">
   <table class="min-w-full">
     <thead class="bg-slate-50">

--- a/templates/churned_allocations.html
+++ b/templates/churned_allocations.html
@@ -3,12 +3,25 @@
 {% block title %}Churned Allocations - EDEMROBIN{% endblock %}
 
 {% block content %}
-<h1 class="text-2xl font-semibold mb-4">Churned (Deactivated) Allocations</h1>
-<p class="text-gray-600 mb-6">This is a list of subnets that have been deactivated and are no longer in use.</p>
+<div class="mb-6 border-b border-slate-200 pb-4">
+    <h1 class="text-2xl font-bold text-slate-700">Churned (Deactivated) Allocations</h1>
+    <p class="text-slate-500">This is a list of subnets that have been deactivated and are no longer in use.</p>
+</div>
 
-<div class="bg-white rounded-xl shadow overflow-x-auto">
+<!-- Search Form -->
+<div class="mb-4">
+    <form action="/dashboard/churned" method="get" class="flex items-center space-x-2">
+        <input type="text" name="query" value="{{ query or '' }}" placeholder="Search by Subnet, Client, or Description..." class="w-full md:w-1/3 px-3 py-2 border border-slate-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 transition">
+        <button type="submit" class="bg-sky-600 text-white font-semibold rounded-lg px-4 py-2 hover:bg-sky-500 transition">Search</button>
+        {% if query %}
+        <a href="/dashboard/churned" class="text-slate-500 hover:text-slate-700 hover:underline">Clear</a>
+        {% endif %}
+    </form>
+</div>
+
+<div class="bg-white rounded-lg shadow-sm border border-slate-200 overflow-x-auto">
   <table class="min-w-full">
-    <thead class="bg-gray-50">
+    <thead class="bg-slate-50">
       <tr>
         <th class="text-left p-3 text-sm font-semibold">Subnet</th>
         <th class="text-left p-3 text-sm font-semibold">VLAN</th>

--- a/templates/nat_ips.html
+++ b/templates/nat_ips.html
@@ -14,6 +14,17 @@
   {% endif %}
 </div>
 
+<!-- Search Form -->
+<div class="mb-4">
+    <form action="/dashboard/nat_ips" method="get" class="flex items-center space-x-2">
+        <input type="text" name="query" value="{{ query or '' }}" placeholder="Search by IP, Client, or Description..." class="w-full md:w-1/3 px-3 py-2 border border-slate-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-sky-500 focus:border-sky-500 transition">
+        <button type="submit" class="bg-sky-600 text-white font-semibold rounded-lg px-4 py-2 hover:bg-sky-500 transition">Search</button>
+        {% if query %}
+        <a href="/dashboard/nat_ips" class="text-slate-500 hover:text-slate-700 hover:underline">Clear</a>
+        {% endif %}
+    </form>
+</div>
+
 <div class="bg-white rounded-lg shadow-sm border border-slate-200 overflow-x-auto">
   <table class="min-w-full">
     <thead class="bg-slate-50">


### PR DESCRIPTION
This commit introduces search functionality to three key pages to improve usability:
- NAT IPs page: Users can now search by IP address, client name, or description.
- VLANs page: Users can now search by VLAN ID or name.
- Churned Allocations page: Users can now search by subnet, client name, or description.

The implementation involves:
- Updating the corresponding routes in `app.py` to accept a search query.
- Modifying the database queries to filter the results based on the search term.
- Adding a search form to the HTML templates for each page.