### PR TITLE
debug: Add validation for starting_ip

### DIFF
--- a/routes_dashboard.py
+++ b/routes_dashboard.py
@@ -211,13 +211,16 @@ def get_available_ips_for_block(request: Request, block_id: int, db: Session = D
 def manual_allocate_action(
     request: Request,
     block_id: int = Form(...),
-    starting_ip: str = Form(...),
+    starting_ip: Optional[str] = Form(None),
     mask: int = Form(...),
     vlan_id: Optional[int] = Form(None),
     description: str = Form(...),
     db: Session = Depends(get_db),
 ):
     user = get_current_user(request, db)
+
+    if not starting_ip:
+        raise HTTPException(status_code=400, detail="Starting IP was not provided. Please select a block and then a starting IP.")
 
     cidr = f"{starting_ip}/{mask}"
 


### PR DESCRIPTION
This commit adds a temporary debugging step to the manual allocation feature. It makes the `starting_ip` field optional on the backend and adds a manual check to return a clearer error message if the field is missing.

This is intended to help diagnose a frontend issue where the `starting_ip` field is not being submitted correctly.