### PR TITLE
fix: Correct client filtering logic

### DIFF
--- a/templates/admin_clients.html
+++ b/templates/admin_clients.html
@@ -41,15 +41,15 @@
             {% endif %}
         </div>
         <div class="flex items-center gap-6 text-sm text-slate-600">
-            <label class="font-medium">Filter by status:</label>
+            <label class="font-medium">Filter by churn status:</label>
             <label class="flex items-center gap-2">
                 <input type="radio" name="status_filter" value="all" onchange="this.form.submit()" {% if status_filter == 'all' %}checked{% endif %}> All
             </label>
             <label class="flex items-center gap-2">
-                <input type="radio" name="status_filter" value="active" onchange="this.form.submit()" {% if status_filter == 'active' %}checked{% endif %}> Active
+                <input type="radio" name="status_filter" value="not_churn" onchange="this.form.submit()" {% if status_filter == 'not_churn' %}checked{% endif %}> Not Churned
             </label>
             <label class="flex items-center gap-2">
-                <input type="radio" name="status_filter" value="inactive" onchange="this.form.submit()" {% if status_filter == 'inactive' %}checked{% endif %}> Inactive (Churned)
+                <input type="radio" name="status_filter" value="churn" onchange="this.form.submit()" {% if status_filter == 'churn' %}checked{% endif %}> Churned
             </label>
         </div>
     </form>


### PR DESCRIPTION
This commit corrects the filtering logic on the 'Manage Clients' page to match the user's specific requirements.

The `status_filter` parameter now distinguishes between 'churn' and 'not_churn' states.
- 'churn': Shows clients that have at least one deactivated subnet.
- 'not_churn': Shows clients that have no deactivated subnets.

The backend query in `app.py` has been updated to perform the necessary joins and filtering on the Subnet table to achieve this. The labels in the `admin_clients.html` template have also been updated to reflect this new logic.