### PR TITLE
feat: Add Device IP Management page

### DIFF
--- a/templates/devices.html
+++ b/templates/devices.html
@@ -1,0 +1,68 @@
+{% extends "layout.html" %}
+{% block title %}Device IP Assignments - IPAM{% endblock %}
+
+{% block content %}
+<div class="mb-6 border-b border-slate-200 pb-4 flex justify-between items-center">
+  <div>
+    <h1 class="text-2xl font-bold text-slate-700">Device IP Assignments</h1>
+    <p class="text-slate-500">A list of all devices with statically assigned IP addresses.</p>
+  </div>
+  <a href="/devices/export_csv" class="bg-slate-800 text-white font-semibold rounded-lg px-4 py-2 text-sm hover:bg-slate-700 transition whitespace-nowrap">
+    Download CSV
+  </a>
+</div>
+
+<!-- Add Device Form -->
+<div class="mb-8">
+    <h2 class="text-lg font-semibold text-slate-700 mb-4">Add New Device Assignment</h2>
+    <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6">
+        <form method="post" action="/devices/add" class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="md:col-span-1">
+                <label for="device_name" class="text-sm font-medium text-slate-600 block mb-1">Device Name</label>
+                <input type="text" name="device_name" id="device_name" class="w-full border-slate-300 rounded-md shadow-sm" placeholder="e.g., core-router-01" required>
+            </div>
+            <div class="md:col-span-1">
+                <label for="ip_address" class="text-sm font-medium text-slate-600 block mb-1">IP Address (with mask)</label>
+                <input type="text" name="ip_address" id="ip_address" class="w-full border-slate-300 rounded-md shadow-sm" placeholder="e.g., 192.168.1.1/24" required>
+            </div>
+            <div class="md:col-span-1">
+                <label for="location" class="text-sm font-medium text-slate-600 block mb-1">Location / Site (optional)</label>
+                <input type="text" name="location" id="location" class="w-full border-slate-300 rounded-md shadow-sm" placeholder="e.g., Main Office">
+            </div>
+            <div class="md:col-span-3 flex justify-end">
+                <button class="bg-slate-800 text-white font-semibold rounded-lg px-4 py-2 text-sm hover:bg-slate-700 transition">Add Device IP</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+
+<div class="bg-white rounded-lg shadow-sm border border-slate-200 overflow-x-auto">
+  <table class="min-w-full">
+    <thead class="bg-slate-50">
+      <tr>
+        <th class="text-left p-4 text-sm font-semibold text-slate-600">Device Name</th>
+        <th class="text-left p-4 text-sm font-semibold text-slate-600">IP Address</th>
+        <th class="text-left p-4 text-sm font-semibold text-slate-600">Interface</th>
+        <th class="text-left p-4 text-sm font-semibold text-slate-600">Location / Site</th>
+      </tr>
+    </thead>
+    <tbody class="divide-y divide-slate-200">
+      {% for device in devices %}
+        {% for iface in device.interfaces %}
+            {% for addr in iface.addresses %}
+            <tr class="hover:bg-slate-50">
+                <td class="p-4 font-semibold text-slate-700">{{ device.hostname }}</td>
+                <td class="p-4 font-mono text-sm">{{ addr.ip }}/{{ addr.prefix }}</td>
+                <td class="p-4 text-sm text-slate-600">{{ iface.name }}</td>
+                <td class="p-4 text-sm text-slate-600">{{ device.site or '-' }}</td>
+            </tr>
+            {% endfor %}
+        {% endfor %}
+      {% else %}
+      <tr><td colspan="4" class="p-6 text-center text-slate-500">No devices with assigned IPs found.</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
This commit introduces a new feature for managing individual device IP assignments.

- A new page is available at `/devices` that lists all devices with statically assigned IPs.
- The page includes a form to add new device assignments, including the device name, its IP address (with mask), and an optional location/site.
- The backend logic correctly finds the containing subnet for the new IP and creates the `Device`, `Interface`, and `InterfaceAddress` records in the database.
- A CSV export feature has been added to allow users to download a complete list of their device assignments.