### PR TITLE
fix: Add link to Devices page in navigation

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -48,6 +48,8 @@
               <li><a href="/admin/clients" class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-700 hover:text-white">🏢 Manage Clients</a></li>
               {% endif %}
 
+              <li><a href="/devices" class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-700 hover:text-white">💻 Devices</a></li>
+
               {% if user.can_manage_nat or user.is_admin %}
               <li><a href="/dashboard/nat_ips" class="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-700 hover:text-white">🔥 NAT IPs</a></li>
               {% endif %}


### PR DESCRIPTION
This commit adds a link to the new 'Device IP Management' page in the main sidebar navigation menu in `templates/layout.html`.

This was an oversight in the initial implementation of the feature and prevented users from accessing the new page.