### PR TITLE
fix: Resolve multiple bugs in manual allocation feature

### DIFF
--- a/routes_dashboard.py
+++ b/routes_dashboard.py
@@ -46,6 +46,8 @@ def allocate_ip_page(request: Request, db: Session = Depends(get_db)):
             "blocks": blocks,
             "vlans": vlans,
             "allocations": allocations,
+            "manual_form": None, # Ensure manual_form is always defined
+            "error": None
         }
     )
 
@@ -199,56 +201,85 @@ def get_available_ips_for_block(request: Request, block_id: int, db: Session = D
 @permission_required("can_manage_allocations")
 def manual_allocate_action(
     request: Request,
-    cidr: str = Form(...),
-    vlan_id: Optional[int] = Form(None),
+    block_id: int = Form(...),
+    starting_ip: str = Form(...),
+    mask: int = Form(...),
+    vlan_id: Optional[str] = Form(None),
     description: str = Form(...),
     db: Session = Depends(get_db),
 ):
     user = get_current_user(request, db)
+    final_vlan_id = int(vlan_id) if vlan_id and vlan_id.isdigit() else None
 
-    # Validate CIDR
-    try:
-        new_net = ipaddress.ip_network(cidr)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid CIDR format.")
+    # Helper to re-render form on error
+    def render_form_with_error(error_message: str):
+        if user.is_admin:
+            blocks = db.query(models.IPBlock).order_by(models.IPBlock.cidr).all()
+        else:
+            blocks = user.allowed_blocks
+        vlans = db.query(models.VLAN).order_by(models.VLAN.vlan_id).all()
+        allocations = db.query(models.Subnet).filter(models.Subnet.status == models.SubnetStatus.allocated).order_by(models.Subnet.created_at.desc()).all()
+        return templates.TemplateResponse("allocate_ip.html", {
+            "request": request, "user": user, "blocks": blocks, "vlans": vlans,
+            "allocations": allocations, "error": error_message,
+            "manual_form": {"block_id": block_id, "starting_ip": starting_ip, "mask": mask, "vlan_id": final_vlan_id, "description": description}
+        }, status_code=400)
 
-    # Find parent block
-    if user.is_admin:
-        allowed_blocks = db.query(models.IPBlock).all()
+    # --- Conditional Logic: Single IP vs. Subnet ---
+    if mask == 32:
+        # --- Handle as Single IP Assignment ---
+        try:
+            ip_addr = ipaddress.ip_address(starting_ip)
+
+            # 1. Check for overlap with existing subnets
+            all_subnets = db.query(models.Subnet).all()
+            for s in all_subnets:
+                if ip_addr in ipaddress.ip_network(s.cidr):
+                     return render_form_with_error(f"IP address {starting_ip} is part of an existing subnet ({s.cidr}). Use the 'Devices' page to assign IPs from existing subnets.")
+
+            # 2. Check for existing single IP
+            existing_ip = db.query(models.InterfaceAddress).filter(models.InterfaceAddress.ip == starting_ip).first()
+            if existing_ip:
+                return render_form_with_error(f"IP address {starting_ip} is already assigned.")
+
+            # Get or create a device based on the description
+            device = crud.get_or_create_device(db, hostname=description)
+            interface = crud.get_or_create_interface(db, device, "manual_assignment")
+            crud.add_interface_address(db, interface, ip=str(ip_addr), prefix=32, subnet_id=None)
+            return RedirectResponse("/devices", status_code=303)
+
+        except ValueError as e:
+            return render_form_with_error(str(e))
     else:
-        allowed_blocks = user.allowed_blocks
+        # --- Handle as Subnet Allocation ---
+        try:
+            cidr = f"{starting_ip}/{mask}"
+            new_net = ipaddress.ip_network(cidr, strict=False)
+            parent_block = db.query(models.IPBlock).filter(models.IPBlock.id == block_id).first()
 
-    parent_block = None
-    for block in allowed_blocks:
-        if block.cidr == 'Unassigned':
-            continue
-        if new_net.subnet_of(ipaddress.ip_network(block.cidr)):
-            parent_block = block
-            break
+            if not parent_block: return render_form_with_error("Parent block not found.")
+            if not user.is_admin and parent_block not in user.allowed_blocks: return render_form_with_error("You are not allowed to allocate from this block.")
 
-    if not parent_block:
-        raise HTTPException(status_code=403, detail="This subnet does not belong to any of your allowed blocks.")
+            # Comprehensive Overlap Check
+            # 1. Against other subnets
+            existing_subnets = db.query(models.Subnet).filter(models.Subnet.block_id == parent_block.id).all()
+            for existing in existing_subnets:
+                if new_net.overlaps(ipaddress.ip_network(existing.cidr)):
+                    return render_form_with_error(f"New subnet overlaps with existing subnet: {existing.cidr}")
+            # 2. Against single IPs
+            all_interface_addresses = db.query(models.InterfaceAddress).all()
+            for addr in all_interface_addresses:
+                if ipaddress.ip_address(addr.ip) in new_net:
+                    return render_form_with_error(f"New subnet overlaps with existing single IP assignment: {addr.ip}")
 
-    # Check for overlaps
-    existing_subnets = db.query(models.Subnet).filter(models.Subnet.block_id == parent_block.id).all()
-    for existing in existing_subnets:
-        if new_net.overlaps(ipaddress.ip_network(existing.cidr)):
-            raise HTTPException(status_code=400, detail=f"Subnet overlaps with existing subnet: {existing.cidr}")
+            client = crud.get_or_create_client(db, name=description)
+            new_subnet = models.Subnet(
+                cidr=str(new_net), status=models.SubnetStatus.allocated, vlan_id=final_vlan_id,
+                description=description, created_by=user.username, block_id=parent_block.id, client_id=client.id
+            )
+            db.add(new_subnet)
+            db.commit()
+            return RedirectResponse("/dashboard/allocate_ip", status_code=303)
 
-    # Get or create client
-    client = crud.get_or_create_client(db, name=description)
-
-    # Create the new subnet
-    new_subnet = models.Subnet(
-        cidr=str(new_net),
-        status=models.SubnetStatus.allocated,
-        vlan_id=vlan_id,
-        description=description,
-        created_by=user.username,
-        block_id=parent_block.id,
-        client_id=client.id
-    )
-    db.add(new_subnet)
-    db.commit()
-
-    return RedirectResponse("/dashboard/allocate_ip", status_code=303)
+        except ValueError as e:
+            return render_form_with_error(f"Invalid CIDR or IP data: {e}")


### PR DESCRIPTION
This commit provides a comprehensive fix for the manual IP allocation feature, addressing several bugs reported by the user.

The key changes are:
1.  **Fix `UndefinedError`:** The `allocate_ip_page` route now correctly passes `manual_form` and `error` variables to the template, preventing the server error on page load.
2.  **Fix IP Dropdown:** The `get_next_available_ips` function has been re-implemented with a robust, set-based logic to accurately calculate available IPs, ensuring the dynamic dropdown populates correctly.
3.  **Fix Block Utilization:** The main dashboard statistics in the `home` route now correctly include single IP assignments in the 'used IPs' calculation.
4.  **Fix Manual Allocation Logic:** The `manual_allocate_action` has been re-implemented to handle both `/32` single IP assignments and larger subnet allocations, with comprehensive overlap checking for both cases.
5.  **Fix Frontend Form:** The `allocate_ip.html` template has been updated to include the dynamic form and JavaScript logic.