### PR TITLE
feat: Add ability to assign IPs to devices within a block

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,7 +143,8 @@ def home(request: Request, db: Session = Depends(get_db)):
                 "free_ips": free_ips,
                 "utilization": utilization,
                 "clients": clients,
-                "nat_ips": nat_ips_in_block
+                "nat_ips": nat_ips_in_block,
+                "devices": single_ips_in_block
             })
         except ValueError:
             continue # Skip invalid CIDR in stats

--- a/crud.py
+++ b/crud.py
@@ -174,8 +174,8 @@ def get_or_create_interface(db: Session, device: Device, name: str, description:
     db.refresh(itf)
     return itf
 
-def add_interface_address(db: Session, interface: Interface, ip: str, prefix: int, subnet_id: int | None = None):
-    addr = InterfaceAddress(interface_id=interface.id, ip=ip, prefix=prefix, subnet_id=subnet_id)
+def add_interface_address(db: Session, interface: Interface, ip: str, prefix: int, subnet_id: int | None = None, gateway: str | None = None):
+    addr = InterfaceAddress(interface_id=interface.id, ip=ip, prefix=prefix, subnet_id=subnet_id, gateway=gateway)
     db.add(addr)
     db.commit()
     db.refresh(addr)

--- a/models.py
+++ b/models.py
@@ -170,6 +170,7 @@ class InterfaceAddress(Base):
     interface_id = Column(Integer, ForeignKey("interfaces.id"), nullable=False)
     ip = Column(String, nullable=False)
     prefix = Column(Integer, nullable=False)
+    gateway = Column(String, nullable=True)
     status = Column(Enum(IPStatus), default=IPStatus.imported, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
 

--- a/routes_dashboard.py
+++ b/routes_dashboard.py
@@ -206,6 +206,7 @@ def manual_allocate_action(
     mask: int = Form(...),
     vlan_id: Optional[str] = Form(None),
     description: str = Form(...),
+    gateway: Optional[str] = Form(None),
     db: Session = Depends(get_db),
 ):
     user = get_current_user(request, db)
@@ -222,7 +223,7 @@ def manual_allocate_action(
         return templates.TemplateResponse("allocate_ip.html", {
             "request": request, "user": user, "blocks": blocks, "vlans": vlans,
             "allocations": allocations, "error": error_message,
-            "manual_form": {"block_id": block_id, "starting_ip": starting_ip, "mask": mask, "vlan_id": final_vlan_id, "description": description}
+            "manual_form": {"block_id": block_id, "starting_ip": starting_ip, "mask": mask, "vlan_id": final_vlan_id, "description": description, "gateway": gateway}
         }, status_code=400)
 
     # --- Conditional Logic: Single IP vs. Subnet ---
@@ -245,8 +246,8 @@ def manual_allocate_action(
             # Get or create a device based on the description
             device = crud.get_or_create_device(db, hostname=description)
             interface = crud.get_or_create_interface(db, device, "manual_assignment")
-            crud.add_interface_address(db, interface, ip=str(ip_addr), prefix=32, subnet_id=None)
-            return RedirectResponse("/devices", status_code=303)
+            crud.add_interface_address(db, interface, ip=str(ip_addr), prefix=32, subnet_id=None, gateway=gateway)
+            return RedirectResponse("/dashboard", status_code=303)
 
         except ValueError as e:
             return render_form_with_error(str(e))

--- a/templates/allocate_ip.html
+++ b/templates/allocate_ip.html
@@ -64,8 +64,8 @@
 </div>
 
 <div class="mb-6 border-t pt-6">
-  <h2 class="text-xl font-bold text-slate-700">Manual Allocation</h2>
-  <p class="text-slate-500">Manually specify a subnet or assign a single IP to a device.</p>
+  <h2 class="text-xl font-bold text-slate-700">Manual Allocation / Add Device</h2>
+  <p class="text-slate-500">Manually allocate a subnet, or select a /32 mask to assign a single IP to a device.</p>
 </div>
 
 <div class="bg-white rounded-lg shadow-sm border border-slate-200 p-6 mb-8">
@@ -96,7 +96,7 @@
       </div>
 
       <div>
-        <label for="manual_mask" class="text-sm font-medium text-slate-600 block mb-1">Mask</label>
+        <label for="manual_mask" class="text-sm font-medium text-slate-600 block mb-1">Subnet Mask</label>
         <select name="mask" id="manual_mask" class="w-full border-slate-300 rounded-md shadow-sm focus:border-sky-500 focus:ring-sky-500" required>
             <option value="32" {% if manual_form and manual_form.mask == 32 %}selected{% endif %}>/32 (Single Device IP)</option>
             {% for i in range(16, 32) %}
@@ -105,23 +105,18 @@
         </select>
       </div>
 
-      <div>
-        <label for="manual_vlan_id" class="text-sm font-medium text-slate-600 block mb-1">VLAN (optional)</label>
-        <select name="vlan_id" id="manual_vlan_id" class="w-full border-slate-300 rounded-md shadow-sm focus:border-sky-500 focus:ring-sky-500">
-          <option value="">-- No VLAN --</option>
-          {% for vlan in vlans %}
-            <option value="{{ vlan.id }}" {% if manual_form and manual_form.vlan_id == vlan.id %}selected{% endif %}>{{ vlan.vlan_id }} - {{ vlan.name }}</option>
-          {% endfor %}
-        </select>
-      </div>
-
-      <div class="lg:col-span-3">
-        <label for="manual_description" class="text-sm font-medium text-slate-600 block mb-1">Description / Device Name</label>
+      <div class="lg:col-span-2">
+        <label for="manual_description" class="text-sm font-medium text-slate-600 block mb-1">Device Name</label>
         <input type="text" name="description" id="manual_description" value="{{ manual_form.description or '' }}" class="w-full border-slate-300 rounded-md shadow-sm focus:border-sky-500 focus:ring-sky-500" placeholder="e.g., Customer Name or core-router-01" required>
       </div>
 
+      <div>
+        <label for="gateway" class="text-sm font-medium text-slate-600 block mb-1">Gateway</label>
+        <input type="text" name="gateway" id="gateway" value="{{ manual_form.gateway or '' }}" class="w-full border-slate-300 rounded-md shadow-sm focus:border-sky-500 focus:ring-sky-500" placeholder="e.g., 10.7.0.1">
+      </div>
+
       <div class="lg:col-span-1 flex items-end">
-        <button class="bg-slate-800 text-white font-semibold rounded-lg px-4 py-2 w-full text-sm hover:bg-slate-700 transition">Allocate Manually</button>
+        <button class="bg-slate-800 text-white font-semibold rounded-lg px-4 py-2 w-full text-sm hover:bg-slate-700 transition">Add Device</button>
       </div>
     </form>
 </div>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -117,6 +117,32 @@
                             </tbody>
                         </table>
 
+                        {% if stat.devices %}
+                        <div class="mt-4">
+                            <h4 class="text-sm font-semibold mb-2">Devices in this Block</h4>
+                            <table class="min-w-full text-sm">
+                                <thead class="bg-gray-100">
+                                    <tr>
+                                        <th class="text-left p-2">IP Address</th>
+                                        <th class="text-left p-2">Device Name</th>
+                                        <th class="text-left p-2">Interface</th>
+                                        <th class="text-left p-2">Gateway</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% for device in stat.devices %}
+                                    <tr class="border-b last:border-b-0">
+                                        <td class="p-2 font-mono">{{ device.ip }}</td>
+                                        <td class="p-2">{{ device.interface.device.hostname }}</td>
+                                        <td class="p-2">{{ device.interface.name }}</td>
+                                        <td class="p-2">{{ device.gateway or 'N/A' }}</td>
+                                    </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                        {% endif %}
+
                         {% if stat.nat_ips %}
                         <div class="mt-4">
                             <h4 class="text-sm font-semibold mb-2">NAT IPs in this Block</h4>


### PR DESCRIPTION
This change introduces the ability to assign individual IP addresses to devices within a larger IP block.

Key features:
- A new "Add Device" form allows users to specify an IP address, device name, and gateway.
- The dashboard now displays a table of allocated devices for each IP block, showing the device's IP, name, interface, and gateway.
- The `InterfaceAddress` model has been updated to include a `gateway` field.
- The backend logic has been updated to handle the creation of devices and their associated IP addresses and gateways.