### PR TITLE
feat: Add ability to assign IPs to devices within a block

### DIFF
--- a/routes_dashboard.py
+++ b/routes_dashboard.py
@@ -248,7 +248,7 @@ def manual_allocate_action(
             device = crud.get_or_create_device(db, hostname=description)
             interface = crud.get_or_create_interface(db, device, "manual_assignment")
             crud.add_interface_address(db, interface, ip=str(ip_addr), prefix=32, subnet_id=None, gateway=gateway)
-            return RedirectResponse("/dashboard", status_code=303)
+            return RedirectResponse("/", status_code=303)
 
         except ValueError as e:
             return render_form_with_error(str(e))


### PR DESCRIPTION
This change introduces the ability to assign individual IP addresses to devices within a larger IP block.

Key features:
- A new "Add Device" form allows users to specify an IP address, device name, and gateway.
- The dashboard now displays a table of allocated devices for each IP block, showing the device's IP, name, interface, and gateway.
- The `InterfaceAddress` model has been updated to include a `gateway` field.
- The backend logic has been updated to handle the creation of devices and their associated IP addresses and gateways.

Bug Fixes:
- Resolves a test failure in the data import logic caused by the schema change.
- Fixes a validation error in the subnet allocation form when no VLAN is selected.
- Corrects a UI bug where a duplicate "Gateway" field was displayed on the allocation form.
- Fixes a bug where the form redirected to the wrong URL after submission.