### PR TITLE
feat: Add ability to assign IPs to devices within a block

### DIFF
--- a/app.py
+++ b/app.py
@@ -441,8 +441,17 @@ def delete_block_action(request: Request, block_id: int, db: Session = Depends(g
     if not block:
         raise HTTPException(status_code=404, detail="IP Block not found")
 
-    # Cascading delete of subnets within this block
-    db.query(models.Subnet).filter(models.Subnet.block_id == block_id).delete(synchronize_session=False)
+    # Get all subnets in the block
+    subnets_in_block = db.query(models.Subnet).filter(models.Subnet.block_id == block_id).all()
+    subnet_ids = [s.id for s in subnets_in_block]
+
+    # Delete all interface addresses associated with those subnets
+    if subnet_ids:
+        db.query(models.InterfaceAddress).filter(models.InterfaceAddress.subnet_id.in_(subnet_ids)).delete(synchronize_session=False)
+
+    # Now, it's safe to delete the subnets
+    if subnet_ids:
+        db.query(models.Subnet).filter(models.Subnet.id.in_(subnet_ids)).delete(synchronize_session=False)
 
     db.delete(block)
     db.commit()


### PR DESCRIPTION
This change introduces the ability to assign individual IP addresses to devices within a larger IP block.

Key features:
- A new "Add Device" form allows users to specify an IP address, device name, and gateway.
- The dashboard now displays a table of allocated devices for each IP block, showing the device's IP, name, interface, and gateway.
- The `InterfaceAddress` model has been updated to include a `gateway` field.
- The backend logic has been updated to handle the creation of devices and their associated IP addresses and gateways.

Bug Fixes:
- Resolves a test failure in the data import logic caused by the schema change.
- Fixes a validation error in the subnet allocation form when no VLAN is selected.
- Corrects a UI bug where a duplicate "Gateway" field was displayed on the allocation form.
- Fixes a bug where the form redirected to the wrong URL after submission.
- Fixes a critical bug that caused a foreign key violation when deleting an IP block with assigned subnets.