### PR TITLE
Fix(devices): Correctly filter and flag core devices

### DIFF
--- a/app.py
+++ b/app.py
@@ -880,7 +880,7 @@ def device_list_page(request: Request, db: Session = Depends(get_db)):
         blocks = db.query(models.IPBlock).order_by(models.IPBlock.cidr).all()
     else:
         blocks = user.allowed_blocks
-    devices = db.query(models.Device).order_by(models.Device.hostname).all()
+    devices = db.query(models.Device).filter(models.Device.is_core_device == True).order_by(models.Device.hostname).all()
     return templates.TemplateResponse("devices.html", {
         "request": request, "user": user, "devices": devices, "blocks": blocks, "error": None
     })
@@ -904,7 +904,7 @@ def add_device_ip_action(
             blocks = db.query(models.IPBlock).order_by(models.IPBlock.cidr).all()
         else:
             blocks = user.allowed_blocks
-        devices = db.query(models.Device).order_by(models.Device.hostname).all()
+        devices = db.query(models.Device).filter(models.Device.is_core_device == True).order_by(models.Device.hostname).all()
         return templates.TemplateResponse("devices.html", {
             "request": request, "user": user, "devices": devices, "blocks": blocks, "error": error_message
         }, status_code=400)
@@ -931,7 +931,8 @@ def add_device_ip_action(
         hostname=hostname,
         site=location,
         username=username,
-        password=password
+        password=password,
+        is_core_device=True
     )
 
     interface_name = f"manual_{ip_addr}"

--- a/crud.py
+++ b/crud.py
@@ -154,13 +154,14 @@ def list_blocks_with_utilization(db: Session):
     return results
 
 # ---------- Devices & Interfaces ----------
-def get_or_create_device(db: Session, hostname: str, vendor: str = "cisco", model: str | None = None, mgmt_ip: str | None = None, site: str | None = None, username: str | None = None, password: str | None = None):
+def get_or_create_device(db: Session, hostname: str, vendor: str = "cisco", model: str | None = None, mgmt_ip: str | None = None, site: str | None = None, username: str | None = None, password: str | None = None, is_core_device: bool = False):
     dev = db.query(Device).filter(Device.hostname == hostname).first()
     if dev:
         if username:
             dev.username = username
         if password:
             dev.password = password
+        dev.is_core_device = is_core_device
         db.commit()
         db.refresh(dev)
         return dev
@@ -172,7 +173,8 @@ def get_or_create_device(db: Session, hostname: str, vendor: str = "cisco", mode
         mgmt_ip=mgmt_ip,
         site=site,
         username=username,
-        password=password
+        password=password,
+        is_core_device=is_core_device
     )
     db.add(dev)
     db.commit()

--- a/models.py
+++ b/models.py
@@ -134,6 +134,7 @@ class Device(Base):
     model = Column(String, nullable=True)
     mgmt_ip = Column(String, nullable=True)
     site = Column(String, nullable=True)
+    is_core_device = Column(Boolean, default=False, nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
 
     interfaces = relationship("Interface", back_populates="device", cascade="all, delete-orphan")


### PR DESCRIPTION
This commit addresses a bug where the device list page (`/devices`) was showing all devices instead of only core devices.

- The query for the device list page is now filtered by the `is_core_device` flag.
- When creating a device via the 'Add Core Device' form, the `is_core_device` flag is now correctly set to `True`.
- The error handling logic on the same page has also been updated to correctly filter devices.