### PR TITLE
Fix(db): Prevent foreign key violation when deleting IP blocks

### DIFF
--- a/app.py
+++ b/app.py
@@ -444,8 +444,21 @@ def delete_block_action(request: Request, block_id: int, db: Session = Depends(g
     if not block:
         raise HTTPException(status_code=404, detail="IP Block not found")
 
-    # Cascading delete of subnets within this block
-    db.query(models.Subnet).filter(models.Subnet.block_id == block_id).delete(synchronize_session=False)
+    # Get subnets to be deleted
+    subnets_to_delete = db.query(models.Subnet).filter(models.Subnet.block_id == block_id).all()
+    if subnets_to_delete:
+        subnet_ids = [s.id for s in subnets_to_delete]
+
+        # Delete associated interface addresses first
+        db.query(models.InterfaceAddress).filter(
+            models.InterfaceAddress.subnet_id.in_(subnet_ids)
+        ).delete(synchronize_session=False)
+
+        # Now delete the subnets
+        db.query(models.Subnet).filter(
+            models.Subnet.id.in_(subnet_ids)
+        ).delete(synchronize_session=False)
+
 
     db.delete(block)
     db.commit()


### PR DESCRIPTION
This commit resolves a `sqlalchemy.exc.IntegrityError` that occurred when attempting to delete an IP block that contained subnets with associated interface addresses.

The `delete_block_action` function in `app.py` has been updated to ensure the correct order of operations for deletion:
1.  It now identifies all subnets within the target block.
2.  It deletes all `interface_addresses` linked to those subnets.
3.  It then deletes the now-unreferenced subnets.
4.  Finally, it deletes the IP block itself.

This change ensures that database foreign key constraints are respected, allowing for the successful deletion of IP blocks and their contents.