### PR TITLE
Feat(ui): Make search bar global

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -55,16 +55,6 @@
             </div>
         </div>
 
-        <!-- Search Bar -->
-        <div class="pb-8">
-            <form action="/dashboard/search" method="get" class="relative">
-                <input type="search" name="query" placeholder="Search for IPs, Subnets, Clients, VLANs..."
-                       class="w-full pl-10 pr-4 py-3 border rounded-full text-lg focus:ring-indigo-500 focus:border-indigo-500">
-                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
-                </div>
-            </form>
-        </div>
     </div>
 
     <!-- Scrollable Content -->

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -88,6 +88,16 @@
 
       <!-- Main content -->
       <main class="flex-1 p-6 overflow-y-auto">
+        <!-- Global Search Bar -->
+        <div class="pb-8 max-w-4xl mx-auto">
+            <form action="/dashboard/search" method="get" class="relative">
+                <input type="search" name="query" placeholder="Search for anything..."
+                       class="w-full pl-10 pr-4 py-3 border rounded-full text-lg focus:ring-sky-500 focus:border-sky-500">
+                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+                </div>
+            </form>
+        </div>
         {% block content %}{% endblock %}
       </main>
     </div>


### PR DESCRIPTION
This commit moves the search bar from the dashboard page to the main layout, making it a global component that appears on all pages.

- The search bar HTML has been removed from `templates/dashboard.html`.
- The search bar HTML has been added to `templates/layout.html`, just above the main content block.
- The placeholder text has been updated to be more generic.
- A `max-width` has been applied to the search bar to improve its appearance on large screens.